### PR TITLE
Improve PMC section extraction and add minimal runner

### DIFF
--- a/pmc_fetch.py
+++ b/pmc_fetch.py
@@ -45,8 +45,29 @@ HEADERS = {
 }
 
 SECTION_KEYS = [
-    ("results", ["results", "results and discussion", "findings"]),
-    ("conclusion", ["conclusion", "conclusions", "concluding remarks", "summary and conclusions"]),
+    (
+        "results",
+        [
+            "results",
+            "result",
+            "results and discussion",
+            "findings",
+            "outcome",
+            "outcomes",
+            "observations",
+        ],
+    ),
+    (
+        "conclusion",
+        [
+            "conclusion",
+            "conclusions",
+            "concluding remarks",
+            "summary and conclusions",
+            "summary",
+            "closing remarks",
+        ],
+    ),
     ("abstract", ["abstract"]),
 ]
 
@@ -90,25 +111,84 @@ def extract_sections(html: str) -> Dict[str, str]:
     soup = BeautifulSoup(html, "lxml")
     article = soup.find("div", id="maincontent") or soup
 
-    def find_section(labels: List[str]) -> str:
-        header = None
-        for h in article.find_all(["h2", "h3"]):
-            title = h.get_text(" ", strip=True).lower()
-            for lab in labels:
-                if title.startswith(lab):
-                    header = h
-                    break
-            if header:
-                break
-        if not header:
+    heading_tags = [f"h{i}" for i in range(1, 7)]
+
+    def _matches_label(text: str, labels: List[str]) -> bool:
+        lowered = text.lower()
+        for lab in labels:
+            if lowered.startswith(lab) or f" {lab} " in f" {lowered} ":
+                return True
+        return False
+
+    def _collect_from_heading(header) -> str:
+        if header is None:
             return ""
-        parts = []
+        current_level = int(header.name[1]) if header.name and header.name[1:].isdigit() else 7
+        parts: List[str] = []
         for sib in header.next_siblings:
-            if getattr(sib, "name", None) in ["h2", "h3"]:
-                break
+            if getattr(sib, "name", None) in heading_tags:
+                level = int(sib.name[1]) if sib.name[1:].isdigit() else 7
+                if level <= current_level:
+                    break
             if hasattr(sib, "get_text"):
-                parts.append(sib.get_text(" ", strip=True))
+                text = sib.get_text(" ", strip=True)
+            else:
+                text = str(sib).strip()
+            if text:
+                parts.append(text)
+        if not parts and header.parent:
+            # Some PMC articles wrap content inside the same parent container.
+            candidate_parent = header.parent
+            texts = []
+            for child in candidate_parent.children:
+                if child == header:
+                    continue
+                if getattr(child, "name", None) in heading_tags:
+                    break
+                if hasattr(child, "get_text"):
+                    t = child.get_text(" ", strip=True)
+                else:
+                    t = str(child).strip()
+                if t:
+                    texts.append(t)
+            if texts:
+                parts.extend(texts)
         return _normalize_ws(" ".join(parts))
+
+    def _search_by_attributes(labels: List[str]) -> Optional[str]:
+        patterns = [re.compile(rf"\b{re.escape(lab)}\b", re.IGNORECASE) for lab in labels]
+        for container in article.find_all(["section", "div", "article"]):
+            attr_chunks = [container.get("id") or "", container.get("title") or ""]
+            classes = container.get("class") or []
+            attr_chunks.extend(classes)
+            attr_text = " ".join(attr_chunks).lower()
+            if any(p.search(attr_text) for p in patterns):
+                text = container.get_text(" ", strip=True)
+                if text:
+                    return _normalize_ws(text)
+        return None
+
+    def find_section(labels: List[str]) -> str:
+        for heading in article.find_all(heading_tags):
+            title = heading.get_text(" ", strip=True)
+            if not title:
+                continue
+            if _matches_label(title, labels):
+                collected = _collect_from_heading(heading)
+                if collected:
+                    return collected
+        attr_match = _search_by_attributes(labels)
+        if attr_match:
+            return attr_match
+        # Fallback: search any element containing the label inline
+        patterns = [re.compile(rf"\b{re.escape(lab)}\b", re.IGNORECASE) for lab in labels]
+        for element in article.find_all(True):
+            text = element.get_text(" ", strip=True)
+            if not text:
+                continue
+            if any(p.search(text) for p in patterns):
+                return _normalize_ws(text)
+        return ""
 
     results = find_section(SECTION_KEYS[0][1])
     conclusion = find_section(SECTION_KEYS[1][1])
@@ -121,24 +201,28 @@ def extract_sections(html: str) -> Dict[str, str]:
 
     return {"results": results, "conclusion": conclusion, "abstract": abstract}
 
-def build_record(pmcid: str, html: Optional[str], meta: Dict[str, str]) -> Optional[Dict]:
-    if not html:
-        return None
-    secs = extract_sections(html)
+def build_record(
+    pmcid: str,
+    meta: Dict[str, str],
+    sections: Dict[str, str],
+    status: str,
+    error: Optional[str] = None,
+) -> Dict:
     record = {
         "pmcid": pmcid,
         "title": meta.get("title") or meta.get("Title") or "",
         "year": _safe_int(meta.get("year") or meta.get("Year")),
         "authors": _split_authors(meta.get("authors") or meta.get("Authors") or ""),
         "sections": {
-            "results": secs.get("results", ""),
-            "conclusion": secs.get("conclusion", ""),
-            "abstract": secs.get("abstract", ""),
+            "results": sections.get("results", ""),
+            "conclusion": sections.get("conclusion", ""),
+            "abstract": sections.get("abstract", ""),
         },
-        "links": {
-            "pmc_html": f"https://pmc.ncbi.nlm.nih.gov/{pmcid}/"
-        }
+        "links": {"pmc_html": f"https://pmc.ncbi.nlm.nih.gov/{pmcid}/"},
+        "status": status,
     }
+    if error:
+        record["error"] = error
     return record
 
 def _safe_int(x):
@@ -184,16 +268,94 @@ def iter_pmcids_from_csv(csv_path: Path, limit: Optional[int]) -> List[Dict]:
 
 def process_one(item, raw_dir: Path, clean_dir: Path, force: bool, session: requests.Session) -> Dict[str, str]:
     pmcid = item["pmcid"]
-    meta = item["meta"]
+    meta = item.get("meta", {})
     try:
         html = fetch_html(pmcid, raw_dir, force, session)
-        rec = build_record(pmcid, html, meta)
-        if rec:
-            save_clean(rec, clean_dir)
-            return {"pmcid": pmcid, "status": "ok"}
-        return {"pmcid": pmcid, "status": "no_record"}
+        if not html:
+            sections = {"results": "", "conclusion": "", "abstract": ""}
+            record = build_record(
+                pmcid,
+                meta,
+                sections,
+                status="no_html",
+                error="Failed to retrieve article HTML",
+            )
+            save_clean(record, clean_dir)
+            return {"pmcid": pmcid, "status": "no_html"}
+
+        sections = extract_sections(html)
+        missing = [k for k in ("results", "conclusion") if not sections.get(k)]
+        status = "ok" if not missing else "missing_sections"
+        record = build_record(pmcid, meta, sections, status=status)
+        if missing:
+            record["missing_sections"] = missing
+        save_clean(record, clean_dir)
+        return {"pmcid": pmcid, "status": status, "missing": missing}
     except Exception as e:
+        sections = {"results": "", "conclusion": "", "abstract": ""}
+        record = build_record(
+            pmcid,
+            meta,
+            sections,
+            status="error",
+            error=str(e),
+        )
+        save_clean(record, clean_dir)
         return {"pmcid": pmcid, "status": f"error: {e}"}
+
+
+def summarize_results(results: List[Dict[str, str]]) -> Dict[str, List[Dict[str, str]]]:
+    summary = {
+        "ok": [],
+        "missing_sections": [],
+        "no_html": [],
+        "errors": [],
+    }
+    for res in results:
+        status = res.get("status", "")
+        if status == "ok":
+            summary["ok"].append(res)
+        elif status == "missing_sections":
+            summary["missing_sections"].append(res)
+        elif status == "no_html":
+            summary["no_html"].append(res)
+        elif status.startswith("error"):
+            summary["errors"].append(res)
+    return summary
+
+
+def run_pipeline(items: List[Dict], out_dir: Path, workers: int, force: bool) -> Dict:
+    ensure_dirs(out_dir)
+    raw_dir = out_dir / "raw"
+    clean_dir = out_dir / "clean"
+
+    session = requests_session()
+
+    items_list = list(items)
+    results: List[Dict[str, str]] = []
+
+    with cf.ThreadPoolExecutor(max_workers=workers) as ex:
+        futures = [
+            ex.submit(process_one, item, raw_dir, clean_dir, force, session)
+            for item in items_list
+        ]
+        if _TQDM:
+            for f in tqdm(cf.as_completed(futures), total=len(items_list), desc="Processing", unit="paper"):
+                results.append(f.result())
+        else:
+            for f in cf.as_completed(futures):
+                results.append(f.result())
+
+    summary = summarize_results(results)
+    report = {
+        "processed": len(results),
+        "ok": len(summary["ok"]),
+        "missing_sections": summary["missing_sections"],
+        "no_html": summary["no_html"],
+        "errors": summary["errors"],
+    }
+    (out_dir / "run_report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return report
 
 def main():
     ap = argparse.ArgumentParser(description="Fetch & cache PMC HTML, extract sections, write JSON.")
@@ -207,40 +369,22 @@ def main():
     ap.add_argument("--force", action="store_true", help="Refetch even if raw HTML exists")
     args = ap.parse_args()
 
-    ensure_dirs(args.out)
-    raw_dir = args.out / "raw"
-    clean_dir = args.out / "clean"
-
     if args.csv:
         items = iter_pmcids_from_csv(args.csv, args.limit)
     else:
         items = [{"pmcid": pmc.strip(), "meta": {}} for pmc in args.pmcids]
-
-    sess = requests_session()
-
-    # Thread pool for I/O bound fetching
-    results = []
-    it = items
-    if _TQDM:
-        it = tqdm(items, desc="Queueing", unit="paper")
-
-    with cf.ThreadPoolExecutor(max_workers=args.workers) as ex:
-        futures = [ex.submit(process_one, item, raw_dir, clean_dir, args.force, sess) for item in items]
-        if _TQDM:
-            for f in tqdm(cf.as_completed(futures), total=len(items), desc="Processing", unit="paper"):
-                results.append(f.result())
-        else:
-            for f in cf.as_completed(futures):
-                results.append(f.result())
-
-    report = {
-        "processed": len(results),
-        "ok": sum(1 for r in results if r["status"] == "ok"),
-        "errors": [r for r in results if r["status"].startswith("error")],
-        "skipped": [r for r in results if r["status"] not in ("ok",) and not r["status"].startswith("error")],
-    }
-    (args.out / "run_report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+    report = run_pipeline(items, args.out, args.workers, args.force)
     print(json.dumps(report, indent=2))
+    print(
+        "Summary: processed {total} papers — {ok} succeeded, {missing} with missing sections,"
+        " {no_html} without HTML, {errors} errors.".format(
+            total=report["processed"],
+            ok=report["ok"],
+            missing=len(report["missing_sections"]),
+            no_html=len(report["no_html"]),
+            errors=len(report["errors"]),
+        )
+    )
 
 if __name__ == "__main__":
     main()

--- a/pmc_min.py
+++ b/pmc_min.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Lightweight wrapper around pmc_fetch to fetch a small sample set."""
+
+import argparse
+import json
+from pathlib import Path
+
+from pmc_fetch import iter_pmcids_from_csv, run_pipeline
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch a minimal subset of PMC articles for smoke testing."
+    )
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        default=Path("SB_publication_PMC.csv"),
+        help="Path to the CSV file containing PMCID entries (default: SB_publication_PMC.csv)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("data"),
+        help="Output base directory (default: data)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=3,
+        help="Number of PMCIDs to process (default: 3)",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=3,
+        help="Number of worker threads to use (default: 3)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force refetching HTML even if cached versions are present",
+    )
+    args = parser.parse_args()
+
+    items = iter_pmcids_from_csv(args.csv, args.limit)
+    report = run_pipeline(items, args.out, args.workers, args.force)
+    print(json.dumps(report, indent=2))
+    print(
+        "Summary: processed {total} papers — {ok} succeeded, {missing} with missing sections," \
+        " {no_html} without HTML, {errors} errors.".format(
+            total=report["processed"],
+            ok=report["ok"],
+            missing=len(report["missing_sections"]),
+            no_html=len(report["no_html"]),
+            errors=len(report["errors"]),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- enhance section extraction logic to handle varied PMC markup, persist status, and record missing sections
- centralize pipeline execution for reuse and emit human-readable run summaries
- add pmc_min.py helper to run a small three-paper smoke test using the shared pipeline

## Testing
- python -m compileall pmc_fetch.py pmc_min.py

------
https://chatgpt.com/codex/tasks/task_e_68e10ff19f408329b03b9dc70a4e599e