### PR TITLE
Fix TypeScript node typings for scripts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client", "node"]
   },
   "include": ["src", "scripts"]
 }


### PR DESCRIPTION
## Summary
- add the Node type definitions to the main TypeScript configuration so Node-specific imports and globals resolve for scripts

## Testing
- npm run build *(fails: vite-plugin-pwa cannot resolve index.html during the build step)*

------
https://chatgpt.com/codex/tasks/task_e_68e11b9dc7848329b46f306de4f179b0