### PR TITLE
Add missing Vite entry HTML file to restore build

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Astro Genesis BioArchive</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add the Vite root `index.html` entry point so the build can locate `src/main.tsx`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11d4973588329b2d1942bb36cbde1