### PR TITLE
Fix base path handling for Cloudflare Pages

### DIFF
--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,0 +1,25 @@
+const ensureTrailingSlash = (value: string) => (value.endsWith('/') ? value : `${value}/`);
+
+const stripLeadingSlash = (value: string) => (value.startsWith('/') ? value.slice(1) : value);
+
+/**
+ * Prefix a relative asset path with the configured Vite base path.
+ */
+export const withBase = (path: string) => {
+  const base = ensureTrailingSlash(import.meta.env.BASE_URL ?? '/');
+  const normalizedPath = stripLeadingSlash(path);
+  return `${base}${normalizedPath}`;
+};
+
+/**
+ * Resolve an asset path to an absolute URL at runtime. Falls back to the base-prefixed path
+ * when running in non-browser environments (e.g. during build-time evaluation).
+ */
+export const resolveAssetUrl = (path: string) => {
+  if (typeof window === 'undefined') {
+    return withBase(path);
+  }
+
+  return new URL(withBase(path), window.location.origin).toString();
+};
+

--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -1,8 +1,11 @@
+import { withBase } from './paths';
+
 export const initPwa = () => {
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
+      const swUrl = withBase('sw.js');
       navigator.serviceWorker
-        .register('/sw.js')
+        .register(swUrl)
         .catch((error) => console.error('SW registration failed', error));
     });
   }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -9,9 +9,10 @@ import CardStack from '../components/CardStack';
 import HudBadge from '../components/HudBadge';
 import { useSearchStore } from '../lib/state';
 import { buildIndex, runSearch, getCachedRecords } from '../lib/search';
+import { withBase } from '../lib/paths';
 
 const fetchIndex = async (): Promise<PaperIndex[]> => {
-  const response = await fetch('/data/index.json');
+  const response = await fetch(withBase('data/index.json'));
   if (!response.ok) throw new Error('Failed to load index');
   return response.json();
 };

--- a/src/routes/Paper.tsx
+++ b/src/routes/Paper.tsx
@@ -7,13 +7,14 @@ import TrendMini from '../components/TrendMini';
 import HudBadge from '../components/HudBadge';
 import { getPaperFromCache, upsertPaperDetail } from '../lib/db';
 import type { PaperDetail } from '../lib/types';
+import { withBase } from '../lib/paths';
 
 const fetchPaper = async (id: string): Promise<PaperDetail> => {
   const cached = await getPaperFromCache(id);
   if (cached && cached.sections && cached.links) {
     return cached as PaperDetail;
   }
-  const response = await fetch(`/data/papers/${id}.json`);
+  const response = await fetch(withBase(`data/papers/${id}.json`));
   if (!response.ok) throw new Error('Failed to fetch dossier');
   const data = (await response.json()) as PaperDetail;
   await upsertPaperDetail(data);

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -3,13 +3,16 @@
 import { precacheAndRoute } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';
 import { StaleWhileRevalidate } from 'workbox-strategies';
+import { withBase } from './lib/paths';
 
 declare let self: ServiceWorkerGlobalScope & { __WB_MANIFEST: Array<any> };
 
 precacheAndRoute(self.__WB_MANIFEST);
 
+const dataPrefix = new URL(withBase('data/'), self.registration.scope).pathname;
+
 registerRoute(
-  ({ url }) => url.pathname.startsWith('/data/'),
+  ({ url }) => url.pathname.startsWith(dataPrefix),
   new StaleWhileRevalidate({
     cacheName: 'bio-data-cache'
   })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
+  base: './',
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- add a helper for constructing URLs that respect the configured Vite base path
- update data fetches, PWA registration, and the service worker to use base-aware URLs so assets load from sub-path deployments
- set the Vite build base to `./` to generate relative asset paths suitable for Cloudflare Pages hosting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e14a89f218832986642c8ea9c1f42e