### PR TITLE
Re-skin interface with classified HUD aesthetic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,23 +57,25 @@ const App = () => {
       <HelpOverlay open={showHelp} onClose={() => setHelp(false)} />
       <CredentialOverlay open={credentialOpen} onClose={() => setCredential(false)} />
       <div className="relative z-10 flex min-h-screen flex-col">
-        <header className="px-6 py-4 border-b border-white/10 backdrop-blur-sm bg-black/40">
+        <header className="px-6 py-4 border-b border-[#123025]/70 bg-[#050d0b]/80 shadow-[0_24px_60px_rgba(0,0,0,0.55)] backdrop-blur-sm">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex items-center gap-4">
-              <div className="rounded-full border border-red/60 px-4 py-1 text-[0.55rem] font-mono uppercase tracking-[0.32em] text-red">
+              <div className="rounded-full border border-red/50 bg-red/10 px-4 py-1 text-[0.55rem] font-mono uppercase tracking-[0.32em] text-red shadow-[0_0_14px_rgba(255,86,72,0.25)]">
                 BioArchive Intelligence
               </div>
-              <span className="font-mono text-[0.6rem] uppercase tracking-[0.3em] text-dim">
+              <span className="font-mono text-[0.6rem] uppercase tracking-[0.3em] text-[#6ab89a]">
                 Offline-first classified ops console
               </span>
             </div>
             <div className="flex items-center gap-4">
-              <nav className="flex gap-4 text-[0.6rem] font-mono uppercase tracking-[0.28em] text-dim">
+              <nav className="flex gap-4 text-[0.6rem] font-mono uppercase tracking-[0.28em] text-[#6d8179]">
                 <NavLink
                   to="/"
                   className={({ isActive }) =>
                     `rounded-full border px-3 py-1 transition-colors ${
-                      isActive ? 'border-amber/70 text-amber' : 'border-transparent hover:text-white/80'
+                      isActive
+                        ? 'border-[#55ffb4]/70 bg-[#0b1f19]/80 text-[#55ffb4] shadow-[0_0_18px_rgba(85,255,180,0.35)]'
+                        : 'border-transparent hover:border-[#123025] hover:text-white/80'
                     }`
                   }
                   end
@@ -84,7 +86,9 @@ const App = () => {
                   to="/tactical"
                   className={({ isActive }) =>
                     `rounded-full border px-3 py-1 transition-colors ${
-                      isActive ? 'border-amber/70 text-amber' : 'border-transparent hover:text-white/80'
+                      isActive
+                        ? 'border-[#55ffb4]/70 bg-[#0b1f19]/80 text-[#55ffb4] shadow-[0_0_18px_rgba(85,255,180,0.35)]'
+                        : 'border-transparent hover:border-[#123025] hover:text-white/80'
                     }`
                   }
                 >
@@ -93,7 +97,7 @@ const App = () => {
               </nav>
               <button
                 type="button"
-                className="rounded-full border border-white/20 px-4 py-1 font-mono text-[0.6rem] uppercase tracking-[0.3em] text-dim hover:text-white/90"
+                className="rounded-full border border-[#123025] bg-[#06120f]/80 px-4 py-1 font-mono text-[0.6rem] uppercase tracking-[0.3em] text-[#6d8179] shadow-[0_0_22px_rgba(0,0,0,0.45)] transition-colors hover:text-white/90"
                 onClick={() => toggleMode()}
               >
                 {mode === 'hud' ? 'Switch to MONO' : 'Switch to HUD'}
@@ -110,7 +114,7 @@ const App = () => {
             </Routes>
           </Suspense>
         </main>
-        <footer className="px-6 py-4 text-[0.55rem] font-mono uppercase tracking-[0.3em] text-dim border-t border-white/10">
+        <footer className="px-6 py-4 border-t border-[#123025]/70 bg-[#040c0a]/80 text-[0.55rem] font-mono uppercase tracking-[0.3em] text-[#6d8179]">
           Signal integrity nominal // Press C for credentials · Press ? for help overlay
         </footer>
       </div>

--- a/src/components/CardStack.tsx
+++ b/src/components/CardStack.tsx
@@ -46,39 +46,39 @@ const StackCard = ({ item, index }: StackCardProps) => {
       onMouseLeave={handleLeave}
     >
       <div
-        className="absolute inset-0 -z-[1] rounded-[26px] border border-white/5 bg-panel/60 backdrop-blur-sm transition-transform duration-500 group-hover:-translate-y-2"
+        className="absolute inset-0 -z-[1] rounded-[26px] border border-[#123025]/50 bg-[#04100d]/70 backdrop-blur-sm transition-transform duration-500 group-hover:-translate-y-2"
         style={{ transform: `translate3d(${tilt.x}px, ${tilt.y}px, 0)` }}
       />
       <article
-        className="relative overflow-hidden rounded-[26px] border border-stroke/60 bg-panel/80 p-6 shadow-panel transition-transform duration-500 group-hover:-translate-y-3"
+        className="relative overflow-hidden rounded-[26px] border border-[#123025]/70 bg-[#061a14]/80 p-6 shadow-[0_28px_60px_rgba(0,0,0,0.5)] transition-transform duration-500 group-hover:-translate-y-3"
         style={{ transform: `translate3d(${tilt.x}px, ${tilt.y}px, 0)` }}
       >
         <header className="mb-4 space-y-3">
-          <div className="flex items-center justify-between text-[0.55rem] uppercase tracking-[0.28em] text-dim">
+          <div className="flex items-center justify-between text-[0.55rem] uppercase tracking-[0.28em] text-[#6d8179]">
             <span>Dossier {index.toString().padStart(3, '0')}</span>
-            <span className="font-mono text-mid">ID // {item.id}</span>
+            <span className="font-mono text-[#6d8179]">ID // {item.id}</span>
           </div>
-          <h2 className="text-lg font-semibold tracking-[0.06em] text-white/95 group-hover:text-amber transition-colors">
+          <h2 className="text-lg font-semibold tracking-[0.06em] text-white/95 transition-colors group-hover:text-cyan">
             {item.title}
           </h2>
-          <p className="font-mono text-[0.62rem] uppercase tracking-[0.28em] text-dim">
+          <p className="font-mono text-[0.62rem] uppercase tracking-[0.28em] text-[#6d8179]">
             {item.authors.join(', ')}
           </p>
         </header>
 
-        <dl className="grid grid-cols-3 gap-2 text-[0.6rem] font-mono uppercase tracking-[0.2em] text-mid">
-          <div className="rounded-md border border-white/10 bg-black/20 px-3 py-2">
-            <dt className="text-[0.55rem] text-dim">Year</dt>
+        <dl className="grid grid-cols-3 gap-2 text-[0.6rem] font-mono uppercase tracking-[0.2em] text-[#6d8179]">
+          <div className="rounded-md border border-[#123025]/70 bg-[#03110d]/80 px-3 py-2">
+            <dt className="text-[0.55rem] text-[#4f625b]">Year</dt>
             <dd className="text-white">{item.year}</dd>
           </div>
-          <div className="rounded-md border border-white/10 bg-black/20 px-3 py-2">
-            <dt className="text-[0.55rem] text-dim">Organism</dt>
+          <div className="rounded-md border border-[#123025]/70 bg-[#03110d]/80 px-3 py-2">
+            <dt className="text-[0.55rem] text-[#4f625b]">Organism</dt>
             <dd className="text-white truncate" title={item.organism}>
               {item.organism}
             </dd>
           </div>
-          <div className="rounded-md border border-white/10 bg-black/20 px-3 py-2">
-            <dt className="text-[0.55rem] text-dim">Platform</dt>
+          <div className="rounded-md border border-[#123025]/70 bg-[#03110d]/80 px-3 py-2">
+            <dt className="text-[0.55rem] text-[#4f625b]">Platform</dt>
             <dd className="text-white truncate" title={item.platform}>
               {item.platform}
             </dd>
@@ -89,7 +89,7 @@ const StackCard = ({ item, index }: StackCardProps) => {
           {item.keywords.slice(0, 4).map((keyword) => (
             <span
               key={keyword}
-              className="rounded-full border border-white/10 bg-black/40 px-3 py-1 text-[0.55rem] font-mono uppercase tracking-[0.28em] text-mid group-hover:border-amber/60"
+              className="rounded-full border border-[#123025] bg-[#03110d]/70 px-3 py-1 text-[0.55rem] font-mono uppercase tracking-[0.28em] text-[#6d8179] transition-colors group-hover:border-[#55ffb4]/60 group-hover:text-white"
             >
               {keyword}
             </span>
@@ -101,7 +101,7 @@ const StackCard = ({ item, index }: StackCardProps) => {
           <HudBadge label="Entities" tone="cyan" compact value={<span>{item.entities.length}</span>} />
         </div>
       </article>
-      <div className="pointer-events-none absolute inset-0 -z-[2] translate-x-2 translate-y-2 rounded-[26px] border border-white/5 bg-panel/30 opacity-70" />
+      <div className="pointer-events-none absolute inset-0 -z-[2] translate-x-2 translate-y-2 rounded-[26px] border border-[#123025]/40 bg-[#03110d]/40 opacity-70" />
     </Link>
   );
 };
@@ -115,17 +115,17 @@ const Battery = ({ confidence }: BatteryProps) => {
   const active = Math.round(confidence * segments);
   return (
     <div className="flex items-center gap-2">
-      <span className="text-[0.55rem] font-mono uppercase tracking-[0.28em] text-dim">Confidence</span>
+      <span className="text-[0.55rem] font-mono uppercase tracking-[0.28em] text-[#6d8179]">Confidence</span>
       <div className="flex items-center gap-1">
-        <div className="flex gap-1 rounded-md border border-white/10 bg-black/40 px-1 py-1">
+        <div className="flex gap-1 rounded-md border border-[#123025]/60 bg-[#03110d]/70 px-1 py-1">
           {Array.from({ length: segments }).map((_, index) => (
             <span
               key={index}
-              className={`h-3 w-2 rounded-sm ${index < active ? 'bg-amber shadow-[0_0_12px_rgba(255,138,0,0.45)]' : 'bg-white/10'}`}
+              className={`h-3 w-2 rounded-sm ${index < active ? 'bg-cyan shadow-[0_0_12px_rgba(85,255,180,0.35)]' : 'bg-white/10'}`}
             />
           ))}
         </div>
-        <span className="font-mono text-[0.6rem] text-mid">{Math.round(confidence * 100)}%</span>
+        <span className="font-mono text-[0.6rem] text-[#6d8179]">{Math.round(confidence * 100)}%</span>
       </div>
     </div>
   );

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -22,14 +22,14 @@ const Filters = ({ organisms, platforms, years }: FilterProps) => {
   }));
 
   return (
-    <aside className="rounded-[28px] border border-white/10 bg-panel/70 p-6 shadow-panel">
+    <aside className="rounded-[28px] border border-[#123025]/70 bg-[#04100d]/80 p-6 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
       <header className="mb-4 flex items-center justify-between">
         <div>
-          <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">Filters</p>
+          <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[#55ffb4]">Filters</p>
           <h3 className="text-lg font-semibold tracking-[0.18em] text-white">Operational Scope</h3>
         </div>
         <button
-          className="rounded-full border border-white/20 px-3 py-1 font-mono text-[0.55rem] uppercase tracking-[0.3em] text-dim hover:text-white/90"
+          className="rounded-full border border-[#123025] bg-[#061a14]/80 px-3 py-1 font-mono text-[0.55rem] uppercase tracking-[0.3em] text-[#6d8179] transition hover:border-[#55ffb4]/60 hover:text-white/90"
           onClick={() => resetFilters()}
           type="button"
         >
@@ -70,7 +70,7 @@ type FilterGroupProps = {
 const FilterGroup = ({ label, options, activeValue, onSelect }: FilterGroupProps) => (
   <div className="space-y-3">
     <div className="flex items-center justify-between">
-      <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">{label}</p>
+      <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[#6d8179]">{label}</p>
       <HudBadge label="Count" tone="cyan" compact value={<span>{options.reduce((acc, option) => acc + option.count, 0)}</span>} />
     </div>
     <div className="flex flex-wrap gap-2">
@@ -81,13 +81,13 @@ const FilterGroup = ({ label, options, activeValue, onSelect }: FilterGroupProps
           className={clsx(
             'group flex items-center gap-2 rounded-full border px-3 py-1 font-mono text-[0.55rem] uppercase tracking-[0.28em] transition-colors duration-200',
             activeValue === option.value
-              ? 'border-amber/60 bg-amber/10 text-amber'
-              : 'border-white/15 text-mid hover:border-amber/40 hover:text-white'
+              ? 'border-[#55ffb4]/70 bg-[#0b1f19]/80 text-[#55ffb4] shadow-[0_0_18px_rgba(85,255,180,0.35)]'
+              : 'border-[#123025] text-[#6d8179] hover:border-[#55ffb4]/50 hover:text-white'
           )}
           onClick={() => onSelect(option.value)}
         >
           <span>{option.label}</span>
-          <span className="rounded-sm bg-black/40 px-1.5 py-0.5 text-[0.55rem] text-dim group-hover:text-white">{option.count}</span>
+          <span className="rounded-sm bg-black/40 px-1.5 py-0.5 text-[0.55rem] text-[#6d8179] group-hover:text-white">{option.count}</span>
         </button>
       ))}
     </div>

--- a/src/components/GridBg.tsx
+++ b/src/components/GridBg.tsx
@@ -1,29 +1,99 @@
 const GridBg = () => {
   return (
     <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
-      <svg className="absolute inset-0 h-full w-full" xmlns="http://www.w3.org/2000/svg">
+      <svg className="absolute inset-0 h-full w-full" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
         <defs>
-          <pattern id="dots" width="24" height="24" patternUnits="userSpaceOnUse">
-            <circle cx="1" cy="1" r="1" fill="rgba(255,255,255,0.08)" />
+          <linearGradient id="bg-gradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="#050a09" />
+            <stop offset="45%" stopColor="#071310" />
+            <stop offset="100%" stopColor="#020605" />
+          </linearGradient>
+          <pattern id="grid" width="80" height="80" patternUnits="userSpaceOnUse">
+            <path d="M80 0H0V80" fill="none" stroke="rgba(87, 129, 116, 0.14)" strokeWidth="0.6" />
           </pattern>
-          <pattern id="grid-lines" width="96" height="96" patternUnits="userSpaceOnUse">
-            <path d="M96 0H0V96" fill="none" stroke="rgba(255,255,255,0.06)" strokeWidth="0.5" />
+          <pattern id="micro-dots" width="16" height="16" patternUnits="userSpaceOnUse">
+            <circle cx="1" cy="1" r="0.9" fill="rgba(160, 214, 185, 0.18)" />
           </pattern>
           <linearGradient id="scan" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="rgba(255,61,46,0.35)" />
-            <stop offset="100%" stopColor="rgba(11,14,16,0)" />
+            <stop offset="0%" stopColor="rgba(255, 86, 72, 0.35)" />
+            <stop offset="100%" stopColor="rgba(3, 7, 6, 0)" />
           </linearGradient>
         </defs>
-        <rect width="100%" height="100%" fill="url(#grid-lines)" opacity="0.35" />
-        <rect width="100%" height="100%" fill="url(#dots)" opacity="0.35" />
-        <rect width="100%" height="100%" fill="url(#scan)" opacity="0.45" />
+        <rect width="100%" height="100%" fill="url(#bg-gradient)" />
+        <rect width="100%" height="100%" fill="url(#grid)" opacity="0.55" />
+        <rect width="100%" height="100%" fill="url(#micro-dots)" opacity="0.35" />
+        <rect width="100%" height="100%" fill="url(#scan)" opacity="0.4" />
       </svg>
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_12%_18%,rgba(255,74,79,0.24),transparent_55%)]" />
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_82%_72%,rgba(85,230,165,0.16),transparent_50%)]" />
-      <div className="absolute inset-0 mix-blend-screen opacity-50"
-        style={{ backgroundImage: 'repeating-linear-gradient(180deg, rgba(255,255,255,0.04) 0, rgba(255,255,255,0.04) 2px, transparent 2px, transparent 6px)' }}
+
+      <div className="absolute inset-0" style={{ backgroundImage: 'radial-gradient(circle at 18% 24%, rgba(108, 208, 162, 0.18), transparent 55%)' }} />
+      <div className="absolute inset-0" style={{ backgroundImage: 'radial-gradient(circle at 82% 68%, rgba(255, 86, 72, 0.16), transparent 48%)' }} />
+
+      <svg
+        className="absolute left-1/2 top-12 h-[180px] w-[960px] -translate-x-1/2 opacity-90 max-w-none"
+        viewBox="0 0 960 180"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <text x="12" y="28" fill="#55ffb4" fontFamily="'IBM Plex Mono', monospace" fontSize="16" letterSpacing={6}>
+          POINTERS
+        </text>
+        <g transform="translate(0 48)" fill="none" stroke="#dfe8e3" strokeWidth="2">
+          <PointerIcon x={40} variant="circle" />
+          <PointerIcon x={140} variant="square" />
+          <PointerIcon x={240} variant="cross" />
+          <PointerIcon x={340} variant="radial" />
+          <PointerIcon x={440} variant="triangle" />
+          <PointerIcon x={540} variant="glitch" />
+          <PointerIcon x={640} variant="skull" />
+          <PointerIcon x={740} variant="arc" />
+          <PointerIcon x={840} variant="scan" />
+        </g>
+      </svg>
+
+      <svg
+        className="absolute left-1/2 top-1/2 h-[220px] w-[1040px] -translate-x-1/2 -translate-y-1/2 opacity-80 max-w-none"
+        viewBox="0 0 1040 220"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <text x="18" y="26" fill="#55ffb4" fontFamily="'IBM Plex Mono', monospace" fontSize="16" letterSpacing={6}>
+          LINE CALLOUT
+        </text>
+        <CalloutPanel x={60} y={60} width={260} label="TEXT" />
+        <CalloutPanel x={368} y={112} width={300} label="TEXT" flip />
+        <CalloutPanel x={704} y={68} width={260} label="TEXT" skew />
+      </svg>
+
+      <svg
+        className="absolute bottom-10 left-1/2 h-[240px] w-[1040px] -translate-x-1/2 opacity-70 max-w-none"
+        viewBox="0 0 1040 240"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <text x="18" y="30" fill="#55ffb4" fontFamily="'IBM Plex Mono', monospace" fontSize="16" letterSpacing={6}>
+          GRID
+        </text>
+        <g transform="translate(60 52)" stroke="#dfe8e3" strokeOpacity="0.25" strokeWidth="1" fill="none">
+          <rect width="360" height="160" rx="14" ry="14" />
+          <path d="M60 0v160" opacity="0.35" />
+          <path d="M0 64h360" opacity="0.35" />
+          <rect x="220" y="28" width="120" height="72" rx="8" ry="8" opacity="0.45" />
+          <path d="M320 0v160" opacity="0.2" />
+          <path d="M0 120h360" opacity="0.2" />
+        </g>
+        <g transform="translate(460 52)">
+          <TriangularGrid />
+        </g>
+        <g transform="translate(760 52)" fill="#dfe8e3">
+          <rect width="220" height="120" fill="rgba(223, 232, 227, 0.04)" />
+          <rect x="12" y="12" width="60" height="60" fill="rgba(223, 232, 227, 0.08)" />
+          <rect x="84" y="28" width="44" height="44" fill="rgba(223, 232, 227, 0.12)" />
+          <rect x="144" y="56" width="36" height="36" fill="rgba(223, 232, 227, 0.16)" />
+        </g>
+      </svg>
+
+      <div
+        className="absolute inset-0 mix-blend-screen opacity-40"
+        style={{ backgroundImage: 'repeating-linear-gradient(180deg, rgba(255,255,255,0.05) 0, rgba(255,255,255,0.05) 1px, transparent 1px, transparent 3px)' }}
       />
-      <div className="absolute inset-6 border border-dashed border-white/5 rounded-[28px]" />
+      <div className="absolute inset-8 rounded-[28px] border border-white/5" />
       <CornerTick position="top-left" />
       <CornerTick position="top-right" />
       <CornerTick position="bottom-left" />
@@ -45,6 +115,200 @@ const CornerTick = ({ position }: CornerTickProps) => {
     'bottom-right': 'right-6 bottom-6 border-l-0 border-t-0 rounded-br-[12px]'
   };
   return <span className={`${common} ${map[position]}`} />;
+};
+
+type PointerVariant =
+  | 'circle'
+  | 'square'
+  | 'cross'
+  | 'radial'
+  | 'triangle'
+  | 'glitch'
+  | 'skull'
+  | 'arc'
+  | 'scan';
+
+type PointerIconProps = {
+  x: number;
+  variant: PointerVariant;
+};
+
+const PointerIcon = ({ x, variant }: PointerIconProps) => {
+  const center = { cx: x, cy: 46 };
+  switch (variant) {
+    case 'circle':
+      return (
+        <g transform={`translate(${center.cx - 32} ${center.cy - 32})`}>
+          <circle cx="32" cy="32" r="30" opacity="0.4" />
+          <circle cx="32" cy="32" r="16" opacity="0.6" />
+          <line x1="32" x2="32" y1="12" y2="0" opacity="0.7" />
+          <line x1="32" x2="32" y1="64" y2="52" opacity="0.7" />
+          <line x1="12" x2="0" y1="32" y2="32" opacity="0.7" />
+          <line x1="64" x2="52" y1="32" y2="32" opacity="0.7" />
+        </g>
+      );
+    case 'square':
+      return (
+        <g transform={`translate(${center.cx - 32} ${center.cy - 32})`}>
+          <rect x="6" y="6" width="52" height="52" rx="4" opacity="0.45" />
+          <path d="M6 6l52 52" opacity="0.5" />
+          <path d="M58 6L6 58" opacity="0.5" />
+          <rect x="26" y="26" width="12" height="12" opacity="0.8" />
+        </g>
+      );
+    case 'cross':
+      return (
+        <g transform={`translate(${center.cx - 32} ${center.cy - 32})`}>
+          <circle cx="32" cy="32" r="30" opacity="0.25" />
+          <path d="M32 0v64M0 32h64" strokeDasharray="6 6" opacity="0.7" />
+          <circle cx="32" cy="32" r="6" opacity="0.8" />
+        </g>
+      );
+    case 'radial':
+      return (
+        <g transform={`translate(${center.cx - 32} ${center.cy - 32})`}>
+          <circle cx="32" cy="32" r="30" strokeDasharray="4 6" opacity="0.4" />
+          <circle cx="32" cy="32" r="18" strokeDasharray="2 4" opacity="0.6" />
+          <path d="M32 12l6 10h-12z" opacity="0.8" />
+          <path d="M32 52l-6-10h12z" opacity="0.8" />
+        </g>
+      );
+    case 'triangle':
+      return (
+        <g transform={`translate(${center.cx - 32} ${center.cy - 30})`}>
+          <polygon points="32,2 62,52 2,52" fill="rgba(255,98,80,0.18)" stroke="rgba(255,98,80,0.75)" />
+          <text
+            x="32"
+            y="38"
+            textAnchor="middle"
+            fontFamily="'IBM Plex Mono', monospace"
+            fontSize="12"
+            fill="rgba(255,98,80,0.8)"
+          >
+            ⚠
+          </text>
+        </g>
+      );
+    case 'glitch':
+      return (
+        <g transform={`translate(${center.cx - 32} ${center.cy - 32})`}>
+          <rect x="8" y="12" width="48" height="40" opacity="0.35" />
+          <path d="M12 16h12v8H12zm20 0h12v8H32zM12 36h12v8H12zm20 12h12v4H32z" opacity="0.8" />
+          <rect x="26" y="26" width="12" height="12" fill="#ff5648" opacity="0.6" />
+        </g>
+      );
+    case 'skull':
+      return (
+        <g transform={`translate(${center.cx - 32} ${center.cy - 32})`}>
+          <circle cx="32" cy="32" r="26" stroke="rgba(255,98,80,0.75)" fill="rgba(255,98,80,0.08)" />
+          <text
+            x="32"
+            y="40"
+            textAnchor="middle"
+            fontFamily="'IBM Plex Mono', monospace"
+            fontSize="20"
+            fill="rgba(255,98,80,0.75)"
+          >
+            ☠
+          </text>
+        </g>
+      );
+    case 'arc':
+      return (
+        <g transform={`translate(${center.cx - 32} ${center.cy - 32})`}>
+          <path d="M32 0a32 32 0 0132 32" strokeDasharray="12 8" opacity="0.6" />
+          <path d="M32 64a32 32 0 01-32-32" strokeDasharray="12 8" opacity="0.35" />
+          <path d="M32 6a26 26 0 0126 26" opacity="0.6" />
+          <circle cx="32" cy="32" r="4" opacity="0.8" />
+        </g>
+      );
+    case 'scan':
+      return (
+        <g transform={`translate(${center.cx - 32} ${center.cy - 32})`}>
+          <rect x="10" y="10" width="44" height="44" rx="12" opacity="0.35" />
+          <path d="M12 32h40" strokeDasharray="4 4" opacity="0.6" />
+          <path d="M32 12v40" strokeDasharray="4 4" opacity="0.6" />
+          <circle cx="32" cy="32" r="20" strokeDasharray="6 6" opacity="0.45" />
+          <rect x="24" y="24" width="16" height="16" fill="#55ffb4" opacity="0.35" />
+        </g>
+      );
+    default:
+      return null;
+  }
+};
+
+type CalloutPanelProps = {
+  x: number;
+  y: number;
+  width: number;
+  label: string;
+  flip?: boolean;
+  skew?: boolean;
+};
+
+const CalloutPanel = ({ x, y, width, label, flip, skew }: CalloutPanelProps) => {
+  const lineY = y + 38;
+  const anchorX = flip ? x + width + 110 : x - 110;
+  const midX = flip ? x + width + 36 : x - 36;
+  const transform = skew ? `rotate(-2 ${x + width / 2} ${y + 42})` : undefined;
+  return (
+    <g>
+      <path
+        d={`M${anchorX} ${lineY} L${midX} ${lineY} L${midX + (flip ? -12 : 12)} ${lineY - 12} L${flip ? x + width : x} ${lineY - 12}`}
+        stroke="#dfe8e3"
+        strokeOpacity="0.4"
+        strokeWidth="1.5"
+        fill="none"
+      />
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={84}
+        rx={12}
+        ry={12}
+        fill="rgba(8, 16, 14, 0.6)"
+        stroke="#dfe8e3"
+        strokeOpacity="0.35"
+        transform={transform}
+      />
+      <text
+        x={x + width / 2}
+        y={y + 48}
+        textAnchor="middle"
+        fill="#dfe8e3"
+        fontFamily="'IBM Plex Mono', monospace"
+        fontSize="20"
+        letterSpacing="10"
+      >
+        {label}
+      </text>
+      <circle cx={anchorX} cy={lineY} r={4} fill="#55ffb4" opacity="0.65" />
+      <circle cx={midX} cy={lineY} r={3} fill="#dfe8e3" opacity="0.45" />
+    </g>
+  );
+};
+
+const TriangularGrid = () => {
+  const lines = [];
+  const size = 200;
+  const step = 18;
+  for (let i = 0; i <= size; i += step) {
+    lines.push(
+      <path key={`diag-${i}`} d={`M0 ${i} L${i} 0`} stroke="rgba(223,232,227,0.18)" strokeWidth="1" />
+    );
+    lines.push(
+      <path key={`diag2-${i}`} d={`M${size - i} ${size} L${size} ${size - i}`} stroke="rgba(223,232,227,0.12)" strokeWidth="1" />
+    );
+  }
+  return (
+    <svg width="220" height="160" viewBox="0 0 200 160" fill="none">
+      <rect width="200" height="160" fill="rgba(223,232,227,0.04)" stroke="rgba(223,232,227,0.25)" rx="10" ry="10" />
+      <g transform="translate(0 0)">
+        {lines}
+      </g>
+    </svg>
+  );
 };
 
 export default GridBg;

--- a/src/components/HudBadge.tsx
+++ b/src/components/HudBadge.tsx
@@ -9,10 +9,10 @@ type HudBadgeProps = {
 };
 
 const toneClass: Record<NonNullable<HudBadgeProps['tone']>, string> = {
-  amber: 'text-amber border-amber/50 shadow-[0_0_18px_rgba(255,176,32,0.18)]',
-  red: 'text-red border-red/60 shadow-[0_0_18px_rgba(255,77,79,0.2)]',
-  cyan: 'text-cyan border-cyan/50 shadow-[0_0_18px_rgba(85,230,165,0.2)]',
-  mono: 'text-white border-white/40 shadow-[0_0_18px_rgba(255,255,255,0.12)]'
+  amber: 'text-amber border-amber/50 shadow-[0_0_18px_rgba(255,131,94,0.22)]',
+  red: 'text-red border-red/60 shadow-[0_0_18px_rgba(255,86,72,0.25)]',
+  cyan: 'text-cyan border-cyan/50 shadow-[0_0_18px_rgba(85,255,180,0.28)]',
+  mono: 'text-white border-white/40 shadow-[0_0_18px_rgba(236,245,240,0.14)]'
 };
 
 const HudBadge = ({ label, value, tone = 'amber', compact }: HudBadgeProps) => {

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -76,10 +76,10 @@ const Home = () => {
 
   return (
     <div className="relative z-10 space-y-10">
-      <section className="grid gap-8 lg:grid-cols-[1.5fr_1fr]">
+      <section className="grid gap-8 rounded-[28px] border border-[#123025]/60 bg-[#050f0d]/70 p-6 lg:grid-cols-[1.5fr_1fr] lg:p-8">
         <div className="space-y-6">
           <header className="space-y-4">
-            <p className="font-mono text-[0.58rem] uppercase tracking-[0.42em] text-dim">BioArchive Intelligence</p>
+            <p className="font-mono text-[0.58rem] uppercase tracking-[0.42em] text-[#55ffb4]">BioArchive Intelligence</p>
             <h1 className="text-4xl font-semibold uppercase tracking-[0.3em] text-white">
               Classified Ops Console
             </h1>
@@ -94,11 +94,11 @@ const Home = () => {
               {indexQuery.isError ? <HudBadge label="Sync" tone="red" value={<span>Failed</span>} /> : null}
             </div>
           </header>
-          <p className="max-w-2xl font-mono text-[0.68rem] uppercase tracking-[0.32em] text-mid">
+          <p className="max-w-2xl font-mono text-[0.68rem] uppercase tracking-[0.32em] text-[#6d8179]">
             Operate the offline-first NASA bioscience archive. Search across mission dossiers, filter by organism, platform, and year, and pivot into branch maps for rapid briefing delivery.
           </p>
           <SearchBox onSearch={() => setResults(runSearch(query, filters))} />
-          <div className="flex items-center gap-3 text-[0.58rem] font-mono uppercase tracking-[0.32em] text-dim">
+          <div className="flex items-center gap-3 text-[0.58rem] font-mono uppercase tracking-[0.32em] text-[#6d8179]">
             <span>Need help?</span>
             <kbd className="rounded border border-white/20 px-2 py-1 text-white/80">?</kbd>
             <span>Open console reference</span>
@@ -107,15 +107,15 @@ const Home = () => {
         <Filters {...filterOptions} />
       </section>
 
-      <section className="space-y-4">
-        <header className="flex items-center justify-between">
+      <section className="space-y-4 rounded-[28px] border border-[#123025]/60 bg-[#050f0d]/70 p-6 lg:p-8">
+        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">Results</p>
+            <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[#55ffb4]">Results</p>
             <h2 className="text-xl font-semibold tracking-[0.22em] text-white">Stacked Dossiers</h2>
           </div>
           <Link
             to="/tactical"
-            className="rounded-full border border-white/20 px-4 py-2 font-mono text-[0.6rem] uppercase tracking-[0.3em] text-dim hover:text-white/90"
+            className="rounded-full border border-[#123025] bg-[#06120f]/70 px-4 py-2 font-mono text-[0.6rem] uppercase tracking-[0.3em] text-[#6d8179] transition hover:border-[#55ffb4]/60 hover:text-white/90"
           >
             Tactical map
           </Link>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,16 +3,16 @@
 @tailwind utilities;
 
 :root {
-  --bg: #0b0e10;
-  --panel: #0f1316;
-  --stroke: #1c2427;
-  --grid: #101519;
-  --amber: #ffb020;
-  --red: #ff4d4f;
-  --cyan: #55e6a5;
-  --white: #e8f2ef;
-  --mid: #a3b8b1;
-  --dim: #6a7b76;
+  --bg: #020705;
+  --panel: rgba(7, 17, 15, 0.78);
+  --stroke: #19352c;
+  --grid: #0b1915;
+  --amber: #ff835e;
+  --red: #ff5648;
+  --cyan: #55ffb4;
+  --white: #ecf5f0;
+  --mid: #b0c9c0;
+  --dim: #6d8179;
   --font-heading: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: 'IBM Plex Mono', 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 }
@@ -36,8 +36,9 @@ body {
 
 body {
   min-height: 100vh;
-  background-image: radial-gradient(circle at top, rgba(255, 74, 79, 0.12), transparent 45%),
-    radial-gradient(circle at 20% 80%, rgba(85, 230, 165, 0.08), transparent 55%);
+  background-image: radial-gradient(circle at 15% 18%, rgba(74, 173, 126, 0.18), transparent 50%),
+    radial-gradient(circle at 82% 78%, rgba(255, 88, 70, 0.15), transparent 52%),
+    linear-gradient(135deg, rgba(5, 12, 10, 0.9) 0%, rgba(2, 6, 5, 0.9) 45%, rgba(7, 19, 16, 0.92) 100%);
   background-attachment: fixed;
 }
 
@@ -61,13 +62,13 @@ a:focus-visible {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(85, 230, 165, 0.35);
+  background: rgba(85, 255, 180, 0.35);
   border-radius: 999px;
 }
 
 ::selection {
-  background: rgba(255, 61, 46, 0.55);
-  color: var(--white);
+  background: rgba(85, 255, 180, 0.4);
+  color: #03231a;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- rebuild the grid backdrop with gradient, pointer reticles, line callouts, and grid overlays that mirror the sci-fi HUD reference
- refresh the global color palette and layout containers to lean into the dark green classified theme across the header, home panels, and filters
- restyle dossier cards, badges, and controls with neon cyan highlights and hazard accents for a cohesive data-console feel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e159f2ef0c8329a5163aa3dcd7f073