### PR TITLE
Streamline UX copy emphasis

### DIFF
--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -94,14 +94,14 @@ const Home = () => {
               {indexQuery.isError ? <HudBadge label="Sync" tone="red" value={<span>Failed</span>} /> : null}
             </div>
           </header>
-          <p className="max-w-2xl font-mono text-[0.68rem] uppercase tracking-[0.32em] text-[#6d8179]">
-            Operate the offline-first NASA bioscience archive. Search across mission dossiers, filter by organism, platform, and year, and pivot into branch maps for rapid briefing delivery.
+          <p className="max-w-2xl font-mono text-[0.68rem] uppercase tracking-[0.32em] text-white/60">
+            Search the offline NASA bioscience archive. Filter dossiers by organism, platform, or year to jump straight to the intel you need.
           </p>
           <SearchBox onSearch={() => setResults(runSearch(query, filters))} />
-          <div className="flex items-center gap-3 text-[0.58rem] font-mono uppercase tracking-[0.32em] text-[#6d8179]">
+          <div className="flex items-center gap-3 text-[0.58rem] font-mono uppercase tracking-[0.32em] text-white/50">
             <span>Need help?</span>
-            <kbd className="rounded border border-white/20 px-2 py-1 text-white/80">?</kbd>
-            <span>Open console reference</span>
+            <kbd className="rounded border border-white/20 px-2 py-1 text-white/70">?</kbd>
+            <span>Press for console reference</span>
           </div>
         </div>
         <Filters {...filterOptions} />

--- a/src/routes/Paper.tsx
+++ b/src/routes/Paper.tsx
@@ -140,8 +140,12 @@ const Paper = () => {
             </Panel>
           </div>
 
-          <Panel title="Analyst Summary" sublabel="AI Channel" actions={<span className="text-dim">LLM uplink pending</span>}>
-            Synthetic analyst summary channel pending activation. Placeholder text demonstrating panel chrome and typographic hierarchy for future LLM integration.
+          <Panel
+            title="Analyst Summary"
+            sublabel="AI Channel"
+            actions={<span className="text-white/50">Uplink offline</span>}
+          >
+            Analyst uplink is offline. The briefing summary will appear here once the channel activates.
           </Panel>
         </div>
 

--- a/src/routes/Tactical.tsx
+++ b/src/routes/Tactical.tsx
@@ -6,8 +6,8 @@ const Tactical = () => {
       <header className="rounded-[28px] border border-white/12 bg-panel/80 p-6 shadow-panel">
         <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">Mission Planning</p>
         <h1 className="mt-2 text-3xl font-semibold uppercase tracking-[0.24em] text-white">Tactical Map Placeholder</h1>
-        <p className="mt-3 max-w-2xl font-mono text-[0.65rem] uppercase tracking-[0.28em] text-mid">
-          Offline static snapshot demonstrating hatch overlays and exclusion zone rendering. Future iterations will wire geospatial layers to mission feeds.
+        <p className="mt-3 max-w-2xl font-mono text-[0.65rem] uppercase tracking-[0.28em] text-white/60">
+          Static preview of exclusion overlays. Live mission feeds will plug into this view next.
         </p>
       </header>
       <ExclusionMap />


### PR DESCRIPTION
## Summary
- tightened hero messaging on the home route to highlight key actions and subdued secondary help text
- clarified tactical route description with concise language and adjusted styling to lower its visual weight
- simplified analyst summary placeholder copy and tone down status text in the dossier view

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e18f423c8c832982014fd842ed0267