### PR TITLE
Add animated splash screen gate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,46 @@
-import { lazy, Suspense, useEffect } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { Routes, Route, NavLink, useLocation } from 'react-router-dom';
 import GridBg from './components/GridBg';
 import InstallPrompt from './components/InstallPrompt';
 import HelpOverlay from './components/HelpOverlay';
 import CredentialOverlay from './components/CredentialOverlay';
+import SplashScreen from './components/SplashScreen';
 import { useUiStore } from './lib/state';
 
 const Home = lazy(() => import('./routes/Home'));
 const Paper = lazy(() => import('./routes/Paper'));
 const Tactical = lazy(() => import('./routes/Tactical'));
 
+const ENTRY_STORAGE_KEY = 'astro-genesis-entered';
+
 const App = () => {
+  const [entered, setEntered] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      return window.localStorage.getItem(ENTRY_STORAGE_KEY) === 'true';
+    } catch (error) {
+      console.warn('Unable to access localStorage', error);
+      return false;
+    }
+  });
+
+  const handleProceed = useCallback(() => {
+    try {
+      window.localStorage.setItem(ENTRY_STORAGE_KEY, 'true');
+    } catch (error) {
+      console.warn('Unable to persist entry state', error);
+    }
+    setEntered(true);
+  }, []);
+
+  if (!entered) {
+    return <SplashScreen onProceed={handleProceed} />;
+  }
+
+  return <AppContent />;
+};
+
+const AppContent = () => {
   const mode = useUiStore((state) => state.mode);
   const toggleMode = useUiStore((state) => state.toggleMode);
   const showHelp = useUiStore((state) => state.showHelp);

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type Props = { onProceed: () => void };
+
+const AUTH_DELAY = 900;
+const PROCEED_DELAY = 700;
+
+export default function SplashScreen({ onProceed }: Props) {
+  const [authing, setAuthing] = useState(false);
+  const [granted, setGranted] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const timers = useRef<number[]>([]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    updatePreference();
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', updatePreference);
+    } else if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(updatePreference);
+    }
+
+    return () => {
+      if (typeof mediaQuery.removeEventListener === 'function') {
+        mediaQuery.removeEventListener('change', updatePreference);
+      } else if (typeof mediaQuery.removeListener === 'function') {
+        mediaQuery.removeListener(updatePreference);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    buttonRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      timers.current.forEach((timer) => window.clearTimeout(timer));
+      timers.current = [];
+    };
+  }, []);
+
+  const handleAuth = useCallback(() => {
+    if (authing) return;
+    setAuthing(true);
+
+    if (prefersReducedMotion) {
+      setGranted(true);
+      onProceed();
+      return;
+    }
+
+    const authTimer = window.setTimeout(() => {
+      setGranted(true);
+      const proceedTimer = window.setTimeout(() => {
+        onProceed();
+      }, PROCEED_DELAY);
+      timers.current.push(proceedTimer);
+    }, AUTH_DELAY);
+    timers.current.push(authTimer);
+  }, [authing, onProceed, prefersReducedMotion]);
+
+  useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === 'enter') {
+        event.preventDefault();
+        handleAuth();
+      }
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [handleAuth]);
+
+  useEffect(() => {
+    const trapFocus = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+      const container = containerRef.current;
+      if (!container) return;
+
+      const focusable = container.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (!active || active === first || !container.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', trapFocus);
+    return () => document.removeEventListener('keydown', trapFocus);
+  }, []);
+
+  return (
+    <div className="splash-wrap" ref={containerRef} role="dialog" aria-modal="true" aria-labelledby="splash-title">
+      <div className="scanlines" aria-hidden="true" />
+      <div className="vignette" aria-hidden="true" />
+
+      <div className="ticks tl" aria-hidden="true" />
+      <div className="ticks tr" aria-hidden="true" />
+      <div className="ticks bl" aria-hidden="true" />
+      <div className="ticks br" aria-hidden="true" />
+
+      <div className="pane">
+        <div className="pane-glow" aria-hidden="true" />
+        <div className="pane-inner" aria-live="polite">
+          <p className="eyebrow">SUBMIT SECURITY CREDENTIALS</p>
+
+          {!granted ? (
+            <>
+              <h1 className="title" id="splash-title">
+                <span className={authing ? 'blink' : ''}>CLASSIFIED</span>
+              </h1>
+              <p className="sub" id="splash-subtitle">
+                PERSONNEL ONLY // ACCESS LEVEL: ALPHA
+              </p>
+
+              <button
+                ref={buttonRef}
+                className={`auth-btn ${authing ? 'is-busy' : ''}`}
+                onClick={handleAuth}
+                aria-label="Authenticate and enter"
+                aria-describedby="splash-subtitle"
+              >
+                {authing ? 'VERIFYING…' : 'AUTHENTICATE'}
+              </button>
+              <p className="hint">Press ENTER</p>
+            </>
+          ) : (
+            <>
+              <h1 className="title granted" id="splash-title">
+                ACCESS GRANTED
+              </h1>
+              <p className="sub ok">IDENTITY CONFIRMED // ROUTING…</p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -131,3 +131,213 @@ a:focus-visible {
     stroke-dashoffset: 0;
   }
 }
+
+/* Splash screen visuals */
+.splash-wrap {
+  --bg: #0b0e10;
+  --panel: #0e1418;
+  --stroke: #1f2a2e;
+  --amber: #ffb020;
+  --yellow: #ffd666;
+  --cyan: #55e6a5;
+  --white: #e8f2ef;
+  --dim: #7a8a86;
+
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(1200px 600px at 50% 45%, #0f1519 0%, var(--bg) 60%, #06090b 100%);
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  color: var(--white);
+  font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  z-index: 999;
+}
+
+.splash-wrap .scanlines,
+.splash-wrap .vignette {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.splash-wrap .scanlines {
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.04) 1px,
+    transparent 2px,
+    transparent 3px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.25;
+  animation: sl 6s linear infinite;
+}
+
+@keyframes sl {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(3px);
+  }
+}
+
+.splash-wrap .vignette {
+  box-shadow: inset 0 0 200px 60px rgba(0, 0, 0, 0.8);
+}
+
+.splash-wrap .ticks {
+  position: absolute;
+  width: 90px;
+  height: 90px;
+  opacity: 0.55;
+}
+
+.splash-wrap .ticks.tl {
+  left: 24px;
+  top: 24px;
+  border-left: 1px solid #39464a;
+  border-top: 1px solid #39464a;
+}
+
+.splash-wrap .ticks.tr {
+  right: 24px;
+  top: 24px;
+  border-right: 1px solid #39464a;
+  border-top: 1px solid #39464a;
+}
+
+.splash-wrap .ticks.bl {
+  left: 24px;
+  bottom: 24px;
+  border-left: 1px solid #39464a;
+  border-bottom: 1px solid #39464a;
+}
+
+.splash-wrap .ticks.br {
+  right: 24px;
+  bottom: 24px;
+  border-right: 1px solid #39464a;
+  border-bottom: 1px solid #39464a;
+}
+
+.splash-wrap .pane {
+  position: relative;
+  width: min(720px, 86vw);
+  border: 1px solid var(--stroke);
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(24, 33, 38, 0.6), rgba(13, 19, 22, 0.6));
+  backdrop-filter: blur(3px) saturate(120%);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05) inset, 0 20px 60px rgba(0, 0, 0, 0.6);
+}
+
+.splash-wrap .pane-glow {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: 12px;
+  box-shadow: 0 0 24px 2px rgba(255, 186, 57, 0.25);
+  pointer-events: none;
+  filter: saturate(120%);
+}
+
+.splash-wrap .pane-inner {
+  padding: 32px 36px 28px;
+  position: relative;
+}
+
+.splash-wrap .eyebrow {
+  letter-spacing: 0.22em;
+  font-size: 12px;
+  color: var(--amber);
+  text-transform: uppercase;
+  opacity: 0.9;
+  margin: 0 0 12px;
+}
+
+.splash-wrap .title {
+  font-size: 34px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0 0 6px;
+  text-shadow: 0 0 10px rgba(255, 186, 57, 0.18);
+}
+
+.splash-wrap .title.granted {
+  color: var(--cyan);
+  text-shadow: 0 0 10px rgba(85, 230, 165, 0.25);
+}
+
+.splash-wrap .sub {
+  color: var(--dim);
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin: 0 0 22px;
+}
+
+.splash-wrap .sub.ok {
+  color: var(--cyan);
+}
+
+.splash-wrap .auth-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  padding: 0 18px;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  border: 1px solid var(--amber);
+  color: var(--white);
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, background-color 0.16s ease;
+  box-shadow: 0 0 0 2px rgba(255, 186, 57, 0.1) inset, 0 0 12px rgba(255, 186, 57, 0.15);
+}
+
+.splash-wrap .auth-btn:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 186, 57, 0.08);
+}
+
+.splash-wrap .auth-btn.is-busy {
+  border-color: #eaa502;
+  box-shadow: 0 0 0 2px rgba(234, 165, 2, 0.18) inset;
+}
+
+.splash-wrap .hint {
+  margin-top: 12px;
+  font-size: 11px;
+  color: #94a39f;
+  opacity: 0.7;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+}
+
+.splash-wrap .blink::after {
+  content: '_';
+  margin-left: 4px;
+  animation: blink 1.05s steps(1, end) infinite;
+  color: var(--yellow);
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .splash-wrap .scanlines {
+    animation: none;
+  }
+
+  .splash-wrap .blink::after {
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a full-screen splash screen component that traps focus, honors reduced-motion preferences, and drives the authentication animation
- persist entry state in localStorage so repeat visitors bypass the splash and load the main console immediately
- wire the splash screen into the app shell and include the supporting global styles for the new experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e19efb53c88329a8bee2469dccf75c