### PR TITLE
Fix OpenAIError import path in summarizer script

### DIFF
--- a/scripts/summarize_jsons.py
+++ b/scripts/summarize_jsons.py
@@ -8,8 +8,7 @@ import os
 from pathlib import Path
 from typing import Dict, Iterable, List
 
-from openai import OpenAI
-from openai.error import OpenAIError
+from openai import OpenAI, OpenAIError
 
 
 PROMPT_TEMPLATE = (


### PR DESCRIPTION
## Summary
- update `scripts/summarize_jsons.py` to import `OpenAIError` from the modern `openai` namespace

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b16368288329a6b7536a1337eef7