### PR TITLE
Tighten copy hierarchy across dossier views

### DIFF
--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -80,7 +80,7 @@ const Home = () => {
         <div className="space-y-6">
           <header className="space-y-4">
             <p className="font-mono text-[0.58rem] uppercase tracking-[0.42em] text-[#55e6a5]">BioArchive Intelligence</p>
-            <h1 className="text-4xl font-semibold uppercase tracking-[0.3em] text-[#d6e3e0]">
+            <h1 className="text-4xl font-semibold uppercase tracking-[0.26em] text-[#f3f8f6]">
               Classified Ops Console
             </h1>
             <div className="flex flex-wrap items-center gap-3">
@@ -94,14 +94,14 @@ const Home = () => {
               {indexQuery.isError ? <HudBadge label="Sync" tone="red" value={<span>Failed</span>} /> : null}
             </div>
           </header>
-          <p className="max-w-2xl font-mono text-[0.68rem] uppercase tracking-[0.32em] text-[#7a8b94]">
-            Operate the offline-first NASA bioscience archive. Search across mission dossiers, filter by organism, platform, and year, and pivot into branch maps for rapid briefing delivery.
+          <p className="max-w-2xl font-mono text-[0.72rem] uppercase tracking-[0.24em] text-[#9fb4bc]">
+            Search the NASA bioscience archive. Filter dossiers by organism, platform, or year to get the right mission intel fast.
           </p>
           <SearchBox onSearch={() => setResults(runSearch(query, filters))} />
-          <div className="flex items-center gap-3 text-[0.58rem] font-mono uppercase tracking-[0.32em] text-[#7a8b94]">
+          <div className="flex items-center gap-3 text-[0.56rem] font-mono uppercase tracking-[0.28em] text-[#5f6c75]">
             <span>Need help?</span>
-            <kbd className="rounded border border-[#d6e3e0]/20 px-2 py-1 text-[#d6e3e0]/80">?</kbd>
-            <span>Open console reference</span>
+            <kbd className="rounded border border-[#d6e3e0]/25 bg-[#0b1116]/70 px-2 py-1 text-[#d6e3e0]/85">?</kbd>
+            <span>Press for console reference</span>
           </div>
         </div>
         <Filters {...filterOptions} />
@@ -127,10 +127,10 @@ const Home = () => {
 };
 
 const EmptyState = () => (
-  <div className="flex h-60 flex-col items-center justify-center rounded-[26px] border border-dashed border-[#d6e3e0]/15 bg-[#0b0d0f]/50 text-center">
-    <p className="font-mono text-[0.62rem] uppercase tracking-[0.32em] text-dim">No dossiers match the current filters.</p>
-    <p className="mt-2 font-mono text-[0.58rem] uppercase tracking-[0.3em] text-mid">
-      Adjust organism, platform, or mission year to widen the search.
+  <div className="flex h-60 flex-col items-center justify-center rounded-[26px] border border-dashed border-[#d6e3e0]/18 bg-[#0b0d0f]/55 text-center">
+    <p className="font-mono text-[0.62rem] uppercase tracking-[0.28em] text-[#b5c5cc]">No dossiers match the current filters.</p>
+    <p className="mt-2 font-mono text-[0.56rem] uppercase tracking-[0.26em] text-mid">
+      Try another organism, platform, or mission year.
     </p>
   </div>
 );

--- a/src/routes/Paper.tsx
+++ b/src/routes/Paper.tsx
@@ -82,9 +82,9 @@ const Paper = () => {
       <header className="relative overflow-hidden rounded-[28px] border border-[#d6e3e0]/12 bg-panel/80 p-6 shadow-panel">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="space-y-2">
-            <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">Dossier {id}</p>
-            <h1 className="text-3xl font-semibold uppercase tracking-[0.24em] text-[#d6e3e0]">{title}</h1>
-            <p className="font-mono text-[0.62rem] uppercase tracking-[0.28em] text-mid">{authors.join(', ')}</p>
+            <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[#55e6a5]">Dossier {id}</p>
+            <h1 className="text-3xl font-semibold uppercase tracking-[0.22em] text-[#f3f8f6]">{title}</h1>
+            <p className="font-mono text-[0.62rem] uppercase tracking-[0.24em] text-[#9fb4bc]">{authors.join(', ')}</p>
           </div>
           <div className="flex flex-wrap items-center gap-3">
             <HudBadge label="Confidence" tone="amber" value={<span>{Math.round(confidence * 100)}%</span>} />
@@ -157,21 +157,25 @@ const Paper = () => {
             </Panel>
           </div>
 
-          <Panel title="Analyst Summary" sublabel="AI Channel" actions={<span className="text-dim">LLM uplink pending</span>}>
-            Synthetic analyst summary channel pending activation. Placeholder text demonstrating panel chrome and typographic hierarchy for future LLM integration.
+          <Panel
+            title="Analyst Summary"
+            sublabel="AI Channel"
+            actions={<span className="text-[#5f6c75]">Uplink offline</span>}
+          >
+            LLM summary feed is offline. This panel will populate once the analyst channel is connected.
           </Panel>
         </div>
 
         <aside className="space-y-6">
-          <div className="rounded-[24px] border border-[#d6e3e0]/12 bg-panel/75 p-5 shadow-panel">
-            <header className="mb-4 font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">Meta</header>
+          <div className="rounded-[24px] border border-[#d6e3e0]/14 bg-panel/80 p-5 shadow-panel">
+            <header className="mb-4 font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#9fb4bc]">Meta</header>
             <dl className="space-y-3 text-[0.82rem]">
               <MetaRow label="Year" value={year.toString()} />
               <MetaRow label="Organism" value={organism} />
               <MetaRow label="Platform" value={platform} />
             </dl>
             <div className="mt-4 space-y-2">
-              <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">Access Flags</p>
+              <p className="font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#5f6c75]">Access Flags</p>
               <div className="flex flex-wrap gap-2">
                 {access.map((flag) => (
                   <HudBadge key={flag} label={flag} tone="red" compact />
@@ -179,7 +183,7 @@ const Paper = () => {
               </div>
             </div>
             <div className="mt-5 space-y-2">
-              <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">Keywords</p>
+              <p className="font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#5f6c75]">Keywords</p>
               <div className="flex flex-wrap gap-2">
                 {keywords.map((keyword) => (
                   <span
@@ -192,7 +196,7 @@ const Paper = () => {
               </div>
             </div>
             <div className="mt-5 space-y-2">
-              <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">Entities</p>
+              <p className="font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#5f6c75]">Entities</p>
               <ul className="grid gap-2 text-[0.62rem] font-mono uppercase tracking-[0.28em] text-mid">
                 {entities.map((entity) => (
                   <li key={entity} className="rounded border border-[#d6e3e0]/10 bg-[#0b0d0f]/30 px-3 py-2">
@@ -202,7 +206,7 @@ const Paper = () => {
               </ul>
             </div>
             <div className="mt-5 space-y-2">
-              <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">External Links</p>
+              <p className="font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#5f6c75]">External Links</p>
               <ul className="space-y-2 text-[0.62rem] font-mono uppercase tracking-[0.28em] text-amber">
                 {links.taskbook ? (
                   <li>
@@ -233,8 +237,8 @@ const Paper = () => {
 
 const MetaRow = ({ label, value }: { label: string; value: string }) => (
   <div className="flex items-center justify-between border-b border-[#d6e3e0]/10 pb-2 last:border-none last:pb-0">
-    <span className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">{label}</span>
-    <span className="text-sm text-[#d6e3e0]">{value}</span>
+    <span className="font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#5f6c75]">{label}</span>
+    <span className="text-sm font-medium text-[#f3f8f6]">{value}</span>
   </div>
 );
 

--- a/src/routes/Tactical.tsx
+++ b/src/routes/Tactical.tsx
@@ -3,11 +3,11 @@ import ExclusionMap from '../components/ExclusionMap';
 const Tactical = () => {
   return (
     <div className="space-y-6">
-      <header className="rounded-[28px] border border-[#d6e3e0]/12 bg-panel/80 p-6 shadow-panel">
-        <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">Mission Planning</p>
-        <h1 className="mt-2 text-3xl font-semibold uppercase tracking-[0.24em] text-[#d6e3e0]">Tactical Map Placeholder</h1>
-        <p className="mt-3 max-w-2xl font-mono text-[0.65rem] uppercase tracking-[0.28em] text-mid">
-          Offline static snapshot demonstrating hatch overlays and exclusion zone rendering. Future iterations will wire geospatial layers to mission feeds.
+      <header className="rounded-[28px] border border-[#d6e3e0]/14 bg-panel/85 p-6 shadow-panel">
+        <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[#55e6a5]">Mission Planning</p>
+        <h1 className="mt-2 text-3xl font-semibold uppercase tracking-[0.22em] text-[#f3f8f6]">Tactical Map</h1>
+        <p className="mt-3 max-w-2xl font-mono text-[0.68rem] uppercase tracking-[0.24em] text-[#9fb4bc]">
+          Static preview of exclusion overlays and hazard zones. Live geospatial data hooks are coming next.
         </p>
       </header>
       <ExclusionMap />


### PR DESCRIPTION
## Summary
- streamline hero, help, and empty state copy on the archive home view and adjust typography to emphasize key actions
- refresh tactical map introduction text to highlight mission planning context while reducing fluff
- clarify dossier detail hierarchy with updated metadata accents and a concise analyst summary placeholder

## Testing
- `npm run lint` *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b06547b88329bf5c2aa704a064a1