### PR TITLE
Update GridBg callout labels with thematic text

### DIFF
--- a/src/components/GridBg.tsx
+++ b/src/components/GridBg.tsx
@@ -57,9 +57,9 @@ const GridBg = () => {
         <text x="18" y="26" fill="#55e6a5" fontFamily="'IBM Plex Mono', monospace" fontSize="16" letterSpacing={6}>
           LINE CALLOUT
         </text>
-        <CalloutPanel x={60} y={60} width={260} label="TEXT" />
-        <CalloutPanel x={368} y={112} width={300} label="TEXT" flip />
-        <CalloutPanel x={704} y={68} width={260} label="TEXT" skew />
+        <CalloutPanel x={60} y={60} width={260} label="ACCESS DENIED" />
+        <CalloutPanel x={368} y={112} width={300} label="CLASSIFIED DOSSIER" flip />
+        <CalloutPanel x={704} y={68} width={260} label="TARGET IDENT" skew />
       </svg>
 
       <svg


### PR DESCRIPTION
## Summary
- replace the placeholder callout panel labels in the GridBg component with thematic wording that matches the Astro Genesis aesthetic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1b076498883299005c4e35697da32