### PR TITLE
Improve search suggestions UX and surface active filters

### DIFF
--- a/src/components/ActiveFiltersBar.tsx
+++ b/src/components/ActiveFiltersBar.tsx
@@ -1,0 +1,71 @@
+import { useSearchStore } from '../lib/state';
+
+const filterLabels: Record<'organism' | 'platform' | 'year', string> = {
+  organism: 'Organism',
+  platform: 'Platform',
+  year: 'Mission Year'
+};
+
+const ActiveFiltersBar = () => {
+  const { filters, setFilters, resetFilters } = useSearchStore((state) => ({
+    filters: state.filters,
+    setFilters: state.setFilters,
+    resetFilters: state.resetFilters
+  }));
+
+  const entries = (Object.entries(filters) as [keyof typeof filters, string | number | null][])
+    .filter(([, value]) => value !== null)
+    .map(([key, value]) => ({
+      key,
+      label: filterLabels[key],
+      value: String(value)
+    }));
+
+  const handleRemove = (key: keyof typeof filters) => {
+    const patch: Partial<typeof filters> = { [key]: null };
+    setFilters(patch);
+  };
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex items-center gap-3 rounded-[20px] border border-[#1a1f24]/70 bg-[#0b0d0f]/60 px-4 py-3 font-mono text-[0.58rem] uppercase tracking-[0.3em] text-[#3f525c] shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
+        <span className="text-[#55e6a5]/70">Filters nominal</span>
+        <span>// All dossiers shown</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-[20px] border border-[#1a1f24]/70 bg-[#0b0d0f]/60 px-4 py-3 shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
+      <span className="font-mono text-[0.58rem] uppercase tracking-[0.3em] text-[#55e6a5]">
+        Active Filters
+      </span>
+      <ul className="flex flex-wrap gap-2">
+        {entries.map((entry) => (
+          <li key={entry.key}>
+            <button
+              type="button"
+              onClick={() => handleRemove(entry.key)}
+              className="group flex items-center gap-2 rounded-full border border-amber/50 bg-[#131d26]/70 px-3 py-1 font-mono text-[0.55rem] uppercase tracking-[0.28em] text-amber transition-colors hover:border-amber/80 hover:bg-amber/10 hover:text-[#d6e3e0]"
+            >
+              <span>{entry.label}</span>
+              <span className="rounded-sm bg-[#0b0d0f]/70 px-1.5 py-0.5 text-[0.55rem] group-hover:bg-amber/20">
+                {entry.value}
+              </span>
+              <span className="text-[#d6e3e0]/70 group-hover:text-[#d6e3e0]">×</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        onClick={() => resetFilters()}
+        className="ml-auto rounded-full border border-[#1a1f24] bg-[#131d26]/70 px-3 py-1 font-mono text-[0.55rem] uppercase tracking-[0.28em] text-[#7a8b94] transition hover:border-[#55e6a5]/60 hover:text-[#d6e3e0]"
+      >
+        Clear All
+      </button>
+    </div>
+  );
+};
+
+export default ActiveFiltersBar;

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useRef } from 'react';
+import { FormEvent, KeyboardEvent, useEffect, useId, useRef, useState } from 'react';
 import { useSearchStore } from '../lib/state';
 import { typeahead } from '../lib/search';
 
@@ -9,7 +9,11 @@ const SearchBox = ({ onSearch }: { onSearch: (term: string) => void }) => {
     suggestions: state.suggestions,
     setSuggestions: state.setSuggestions
   }));
-  const listRef = useRef<HTMLUListElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const activeItemRef = useRef<HTMLLIElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+  const listboxId = useId();
 
   useEffect(() => {
     const next = typeahead(query).map((item) => ({
@@ -20,13 +24,85 @@ const SearchBox = ({ onSearch }: { onSearch: (term: string) => void }) => {
     setSuggestions(next);
   }, [query, setSuggestions]);
 
+  useEffect(() => {
+    if (suggestions.length > 0 && query.trim().length > 0) {
+      setOpen(true);
+      setActiveIndex((current) => (current >= 0 && current < suggestions.length ? current : 0));
+    } else {
+      setOpen(false);
+      setActiveIndex(-1);
+    }
+  }, [suggestions, query]);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  useEffect(() => {
+    if (activeItemRef.current) {
+      activeItemRef.current.scrollIntoView({ block: 'nearest' });
+    }
+  }, [activeIndex]);
+
+  const handleSuggestionSelect = (title: string) => {
+    setQuery(title);
+    onSearch(title);
+    setOpen(false);
+    setActiveIndex(-1);
+  };
+
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
-    onSearch(query);
+    onSearch(query.trim());
+    setOpen(false);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (!open && ['ArrowDown', 'ArrowUp'].includes(event.key) && suggestions.length > 0) {
+      setOpen(true);
+      setActiveIndex(0);
+      event.preventDefault();
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowDown':
+        if (suggestions.length === 0) return;
+        event.preventDefault();
+        setActiveIndex((index) => (index + 1) % suggestions.length);
+        break;
+      case 'ArrowUp':
+        if (suggestions.length === 0) return;
+        event.preventDefault();
+        setActiveIndex((index) => (index - 1 + suggestions.length) % suggestions.length);
+        break;
+      case 'Enter':
+        if (open && activeIndex >= 0 && suggestions[activeIndex]) {
+          event.preventDefault();
+          handleSuggestionSelect(suggestions[activeIndex].title);
+        }
+        break;
+      case 'Escape':
+        if (open) {
+          event.preventDefault();
+          setOpen(false);
+          setActiveIndex(-1);
+        }
+        break;
+      default:
+        break;
+    }
   };
 
   return (
-    <div className="relative w-full max-w-xl">
+    <div ref={containerRef} className="relative w-full max-w-xl">
       <form
         onSubmit={handleSubmit}
         className="flex items-center gap-3 rounded-[28px] border border-[#d6e3e0]/10 bg-[#0b0d0f]/60 px-5 py-3 shadow-panel"
@@ -39,6 +115,13 @@ const SearchBox = ({ onSearch }: { onSearch: (term: string) => void }) => {
           type="search"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
+          onFocus={() => setOpen(suggestions.length > 0 && query.trim().length > 0)}
+          onKeyDown={handleKeyDown}
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={open}
+          aria-controls={open ? listboxId : undefined}
+          aria-activedescendant={open && activeIndex >= 0 ? `${listboxId}-${suggestions[activeIndex]?.id}` : undefined}
           className="flex-1 bg-transparent font-mono text-[0.85rem] uppercase tracking-[0.28em] text-[#d6e3e0] placeholder:text-dim focus:outline-none"
           placeholder="Title / authors / keywords"
         />
@@ -49,20 +132,31 @@ const SearchBox = ({ onSearch }: { onSearch: (term: string) => void }) => {
           Execute
         </button>
       </form>
-      {suggestions.length > 0 && query.length > 0 ? (
+      {open && suggestions.length > 0 ? (
         <ul
-          ref={listRef}
-          className="absolute z-20 mt-2 w-full overflow-hidden rounded-[20px] border border-[#d6e3e0]/12 bg-panel/90 backdrop-blur-xl text-left shadow-panel"
+          id={listboxId}
+          role="listbox"
+          aria-label="Suggested dossiers"
+          className="absolute z-20 mt-2 max-h-72 w-full overflow-auto rounded-[20px] border border-[#d6e3e0]/12 bg-panel/90 backdrop-blur-xl text-left shadow-panel"
         >
-          {suggestions.map((item) => (
-            <li key={item.id}>
+          {suggestions.map((item, index) => (
+            <li
+              key={item.id}
+              id={`${listboxId}-${item.id}`}
+              ref={index === activeIndex ? activeItemRef : undefined}
+            >
               <button
                 type="button"
-                className="flex w-full items-center justify-between gap-3 px-4 py-3 font-mono text-[0.62rem] uppercase tracking-[0.26em] text-mid hover:bg-amber/10 hover:text-[#d6e3e0]"
-                onClick={() => {
-                  setQuery(item.title);
-                  onSearch(item.title);
-                }}
+                role="option"
+                aria-selected={index === activeIndex}
+                className={
+                  'flex w-full items-center justify-between gap-3 px-4 py-3 font-mono text-[0.62rem] uppercase tracking-[0.26em] transition-colors ' +
+                  (index === activeIndex
+                    ? 'bg-amber/10 text-[#d6e3e0] shadow-[0_0_18px_rgba(244,159,66,0.22)]'
+                    : 'text-mid hover:bg-amber/10 hover:text-[#d6e3e0]')
+                }
+                onClick={() => handleSuggestionSelect(item.title)}
+                onMouseEnter={() => setActiveIndex(index)}
               >
                 <span className="truncate text-left">{item.title}</span>
                 <span className="text-dim">{item.year || '—'}</span>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -7,6 +7,7 @@ import Filters from '../components/Filters';
 import SearchBox from '../components/SearchBox';
 import CardStack from '../components/CardStack';
 import HudBadge from '../components/HudBadge';
+import ActiveFiltersBar from '../components/ActiveFiltersBar';
 import { useSearchStore } from '../lib/state';
 import { buildIndex, runSearch, getCachedRecords } from '../lib/search';
 import { withBase } from '../lib/paths';
@@ -97,7 +98,10 @@ const Home = () => {
           <p className="max-w-2xl font-mono text-[0.68rem] uppercase tracking-[0.32em] text-[#7a8b94]">
             Operate the offline-first NASA bioscience archive. Search across mission dossiers, filter by organism, platform, and year, and pivot into branch maps for rapid briefing delivery.
           </p>
-          <SearchBox onSearch={() => setResults(runSearch(query, filters))} />
+          <div className="space-y-4">
+            <SearchBox onSearch={() => setResults(runSearch(query, filters))} />
+            <ActiveFiltersBar />
+          </div>
           <div className="flex items-center gap-3 text-[0.58rem] font-mono uppercase tracking-[0.32em] text-[#7a8b94]">
             <span>Need help?</span>
             <kbd className="rounded border border-[#d6e3e0]/20 px-2 py-1 text-[#d6e3e0]/80">?</kbd>


### PR DESCRIPTION
## Summary
- add keyboard navigation, focus management, and aria metadata to the dossier search suggestions
- close the typeahead intelligently when clicking away or submitting queries to streamline usage
- surface active filter chips with quick removal controls to clarify the applied scope

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1b27f8978832995bbb1b5d01a6f28