### PR TITLE
Sharpen UI surfaces and darken overlay backgrounds

### DIFF
--- a/src/components/ActiveFiltersBar.tsx
+++ b/src/components/ActiveFiltersBar.tsx
@@ -28,7 +28,7 @@ const ActiveFiltersBar = () => {
 
   if (entries.length === 0) {
     return (
-      <div className="flex items-center gap-3 rounded-[20px] border border-[#1a1f24]/70 bg-[#0b0d0f]/60 px-4 py-3 font-mono text-[0.58rem] uppercase tracking-[0.3em] text-[#3f525c] shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
+      <div className="flex items-center gap-3 rounded-[3px] border border-[#1a1f24]/70 bg-[#0b0d0f]/70 px-4 py-3 font-mono text-[0.58rem] uppercase tracking-[0.3em] text-[#3f525c] shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
         <span className="text-[#55e6a5]/70">Filters nominal</span>
         <span>// All dossiers shown</span>
       </div>
@@ -36,7 +36,7 @@ const ActiveFiltersBar = () => {
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-3 rounded-[20px] border border-[#1a1f24]/70 bg-[#0b0d0f]/60 px-4 py-3 shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
+    <div className="flex flex-wrap items-center gap-3 rounded-[3px] border border-[#1a1f24]/70 bg-[#0b0d0f]/70 px-4 py-3 shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
       <span className="font-mono text-[0.58rem] uppercase tracking-[0.3em] text-[#55e6a5]">
         Active Filters
       </span>

--- a/src/components/BranchMap.tsx
+++ b/src/components/BranchMap.tsx
@@ -26,7 +26,7 @@ const BranchMap = ({ title, activeSection, onSectionChange }: BranchMapProps) =>
   const edges = useMemo<Edge[]>(() => createEdges(layout), [layout]);
 
   return (
-    <div className="relative overflow-hidden rounded-[28px] border border-[#d6e3e0]/10 bg-panel/70 backdrop-blur-sm">
+    <div className="relative overflow-hidden rounded-[3px] border border-[#d6e3e0]/10 bg-panel/85 backdrop-blur-sm">
       <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-between border-b border-[#d6e3e0]/10 bg-[#0b0d0f]/40 px-5 py-3 text-[0.58rem] font-mono uppercase tracking-[0.32em] text-dim">
         <span>Branch Map // Narrative Threads</span>
         <div className="flex items-center gap-2">

--- a/src/components/CardStack.tsx
+++ b/src/components/CardStack.tsx
@@ -46,11 +46,11 @@ const StackCard = ({ item, index }: StackCardProps) => {
       onMouseLeave={handleLeave}
     >
       <div
-        className="absolute inset-0 -z-[1] rounded-[26px] border border-[#1a1f24]/50 bg-[#10161d]/70 backdrop-blur-sm transition-transform duration-500 group-hover:-translate-y-2"
+        className="absolute inset-0 -z-[1] rounded-[4px] border border-[#1a1f24]/50 bg-[#10161d]/75 backdrop-blur-sm transition-transform duration-500 group-hover:-translate-y-2"
         style={{ transform: `translate3d(${tilt.x}px, ${tilt.y}px, 0)` }}
       />
       <article
-        className="relative overflow-hidden rounded-[26px] border border-[#1a1f24]/70 bg-[#131d26]/80 p-6 shadow-[0_28px_60px_rgba(0,0,0,0.5)] transition-transform duration-500 group-hover:-translate-y-3"
+        className="relative overflow-hidden rounded-[4px] border border-[#1a1f24]/70 bg-[#131d26]/85 p-6 shadow-[0_28px_60px_rgba(0,0,0,0.5)] transition-transform duration-500 group-hover:-translate-y-3"
         style={{ transform: `translate3d(${tilt.x}px, ${tilt.y}px, 0)` }}
       >
         <header className="mb-4 space-y-3">
@@ -67,17 +67,17 @@ const StackCard = ({ item, index }: StackCardProps) => {
         </header>
 
         <dl className="grid grid-cols-3 gap-2 text-[0.6rem] font-mono uppercase tracking-[0.2em] text-[#7a8b94]">
-          <div className="rounded-md border border-[#1a1f24]/70 bg-[#141c24]/80 px-3 py-2">
+          <div className="rounded-[3px] border border-[#1a1f24]/70 bg-[#141c24]/80 px-3 py-2">
             <dt className="text-[0.55rem] text-[#5d6c75]">Year</dt>
             <dd className="text-[#d6e3e0]">{item.year}</dd>
           </div>
-          <div className="rounded-md border border-[#1a1f24]/70 bg-[#141c24]/80 px-3 py-2">
+          <div className="rounded-[3px] border border-[#1a1f24]/70 bg-[#141c24]/80 px-3 py-2">
             <dt className="text-[0.55rem] text-[#5d6c75]">Organism</dt>
             <dd className="text-[#d6e3e0] truncate" title={item.organism}>
               {item.organism}
             </dd>
           </div>
-          <div className="rounded-md border border-[#1a1f24]/70 bg-[#141c24]/80 px-3 py-2">
+          <div className="rounded-[3px] border border-[#1a1f24]/70 bg-[#141c24]/80 px-3 py-2">
             <dt className="text-[0.55rem] text-[#5d6c75]">Platform</dt>
             <dd className="text-[#d6e3e0] truncate" title={item.platform}>
               {item.platform}
@@ -101,7 +101,7 @@ const StackCard = ({ item, index }: StackCardProps) => {
           <HudBadge label="Entities" tone="cyan" compact value={<span>{item.entities.length}</span>} />
         </div>
       </article>
-      <div className="pointer-events-none absolute inset-0 -z-[2] translate-x-2 translate-y-2 rounded-[26px] border border-[#1a1f24]/40 bg-[#141c24]/40 opacity-70" />
+      <div className="pointer-events-none absolute inset-0 -z-[2] translate-x-2 translate-y-2 rounded-[4px] border border-[#1a1f24]/40 bg-[#141c24]/45 opacity-70" />
     </Link>
   );
 };
@@ -117,7 +117,7 @@ const Battery = ({ confidence }: BatteryProps) => {
     <div className="flex items-center gap-2">
       <span className="text-[0.55rem] font-mono uppercase tracking-[0.28em] text-[#7a8b94]">Confidence</span>
       <div className="flex items-center gap-1">
-        <div className="flex gap-1 rounded-md border border-[#1a1f24]/60 bg-[#141c24]/70 px-1 py-1">
+        <div className="flex gap-1 rounded-[3px] border border-[#1a1f24]/60 bg-[#141c24]/70 px-1 py-1">
           {Array.from({ length: segments }).map((_, index) => (
             <span
               key={index}

--- a/src/components/CredentialOverlay.tsx
+++ b/src/components/CredentialOverlay.tsx
@@ -24,7 +24,7 @@ const CredentialOverlay = ({ open, onClose }: CredentialOverlayProps) => {
 
   return createPortal(
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-[#0b0d0f]/80 backdrop-blur-sm">
-      <div className="relative w-full max-w-md overflow-hidden rounded-[30px] border border-[#d6e3e0]/15 bg-panel/90 p-8 shadow-[0_20px_60px_rgba(0,0,0,0.65)]">
+      <div className="relative w-full max-w-md overflow-hidden rounded-[4px] border border-[#d6e3e0]/15 bg-panel/95 p-8 shadow-[0_20px_60px_rgba(0,0,0,0.65)]">
         <div className="absolute inset-0 scanlines" />
         <header className="relative mb-6 space-y-3 text-center">
           <HudBadge label="Level 7" tone="red" value={<span>SECURE</span>} />
@@ -46,7 +46,7 @@ const CredentialOverlay = ({ open, onClose }: CredentialOverlayProps) => {
             <input
               ref={inputRef}
               type="password"
-              className="mt-2 w-full rounded-[16px] border border-[#d6e3e0]/15 bg-[#0b0d0f]/60 px-4 py-3 font-mono text-[0.8rem] tracking-[0.28em] text-[#d6e3e0] focus:border-amber focus:outline-none"
+              className="mt-2 w-full rounded-[3px] border border-[#d6e3e0]/20 bg-[#0b0d0f]/70 px-4 py-3 font-mono text-[0.8rem] tracking-[0.28em] text-[#d6e3e0] focus:border-amber focus:outline-none"
               placeholder="••••-••••-••••"
               required
             />
@@ -55,14 +55,14 @@ const CredentialOverlay = ({ open, onClose }: CredentialOverlayProps) => {
             Operator Call Sign
             <input
               type="text"
-              className="mt-2 w-full rounded-[16px] border border-[#d6e3e0]/15 bg-[#0b0d0f]/60 px-4 py-3 font-mono text-[0.8rem] tracking-[0.28em] text-[#d6e3e0] focus:border-amber focus:outline-none"
+              className="mt-2 w-full rounded-[3px] border border-[#d6e3e0]/20 bg-[#0b0d0f]/70 px-4 py-3 font-mono text-[0.8rem] tracking-[0.28em] text-[#d6e3e0] focus:border-amber focus:outline-none"
               placeholder="e.g. ORION-12"
               required
             />
           </label>
           <button
             type="submit"
-            className="hud-glow relative w-full rounded-[18px] border border-red/60 bg-gradient-to-r from-red/80 to-amber/70 py-3 font-mono text-[0.75rem] uppercase tracking-[0.32em] text-[#d6e3e0]"
+            className="hud-glow relative w-full rounded-[4px] border border-red/60 bg-gradient-to-r from-red/85 to-amber/75 py-3 font-mono text-[0.75rem] uppercase tracking-[0.32em] text-[#d6e3e0]"
           >
             Authenticate
           </button>

--- a/src/components/DossierGlyphs.tsx
+++ b/src/components/DossierGlyphs.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 
 const TargetingHUD = () => {
   return (
-    <div className="relative overflow-hidden rounded-[24px] border border-white/10 bg-black/70 p-6 text-white/80 shadow-panel">
+    <div className="relative overflow-hidden rounded-[3px] border border-white/10 bg-black/75 p-6 text-white/80 shadow-panel">
       <div className="pointer-events-none absolute inset-0 opacity-40 mix-blend-screen">
         <div className="absolute left-1/2 top-0 h-full w-px -translate-x-1/2 bg-white/20" />
         <div className="absolute top-1/2 left-0 h-px w-full -translate-y-1/2 bg-white/20" />
@@ -49,7 +49,7 @@ const TargetingHUD = () => {
 
 const VectorLattice = () => {
   return (
-    <div className="relative overflow-hidden rounded-[24px] border border-white/10 bg-black/70 p-6 text-white/80 shadow-panel">
+    <div className="relative overflow-hidden rounded-[3px] border border-white/10 bg-black/75 p-6 text-white/80 shadow-panel">
       <div className="relative flex h-64 flex-col justify-between font-mono text-[0.58rem] uppercase tracking-[0.28em] text-dim">
         <div className="flex justify-between">
           <span>Grid Vec</span>

--- a/src/components/ExclusionMap.tsx
+++ b/src/components/ExclusionMap.tsx
@@ -1,6 +1,6 @@
 const ExclusionMap = () => {
   return (
-    <div className="relative overflow-hidden rounded-[28px] border border-[#d6e3e0]/10 bg-[#0b0d0f]/80 shadow-panel">
+    <div className="relative overflow-hidden rounded-[3px] border border-[#d6e3e0]/10 bg-[#0b0d0f]/85 shadow-panel">
       <header className="absolute left-6 top-6 z-20 flex items-center gap-3 font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[#d6e3e0]">
         <span className="rounded-full border border-red/60 px-3 py-1 text-red">Exclusion Zone</span>
         <span className="text-dim">S-17 Quadrant</span>

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -22,7 +22,7 @@ const Filters = ({ organisms, platforms, years }: FilterProps) => {
   }));
 
   return (
-    <aside className="rounded-[28px] border border-[#1a1f24]/70 bg-[#10161d]/80 p-6 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+    <aside className="rounded-[3px] border border-[#1a1f24]/70 bg-[#10161d]/85 p-6 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
       <header className="mb-4 flex items-center justify-between">
         <div>
           <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[#55e6a5]">Filters</p>

--- a/src/components/GridBg.tsx
+++ b/src/components/GridBg.tsx
@@ -93,7 +93,7 @@ const GridBg = () => {
         className="absolute inset-0 mix-blend-screen opacity-40"
         style={{ backgroundImage: 'repeating-linear-gradient(180deg, rgba(214,227,224,0.05) 0, rgba(214,227,224,0.05) 1px, transparent 1px, transparent 3px)' }}
       />
-      <div className="absolute inset-8 rounded-[28px] border border-[#d6e3e0]/5" />
+      <div className="absolute inset-8 rounded-[4px] border border-[#d6e3e0]/5" />
       <CornerTick position="top-left" />
       <CornerTick position="top-right" />
       <CornerTick position="bottom-left" />
@@ -109,10 +109,10 @@ type CornerTickProps = {
 const CornerTick = ({ position }: CornerTickProps) => {
   const common = 'absolute h-8 w-8 border border-[#d6e3e0]/10';
   const map: Record<CornerTickProps['position'], string> = {
-    'top-left': 'left-6 top-6 border-r-0 border-b-0 rounded-tl-[12px]',
-    'top-right': 'right-6 top-6 border-l-0 border-b-0 rounded-tr-[12px]',
-    'bottom-left': 'left-6 bottom-6 border-r-0 border-t-0 rounded-bl-[12px]',
-    'bottom-right': 'right-6 bottom-6 border-l-0 border-t-0 rounded-br-[12px]'
+    'top-left': 'left-6 top-6 border-r-0 border-b-0 rounded-tl-[3px]',
+    'top-right': 'right-6 top-6 border-l-0 border-b-0 rounded-tr-[3px]',
+    'bottom-left': 'left-6 bottom-6 border-r-0 border-t-0 rounded-bl-[3px]',
+    'bottom-right': 'right-6 bottom-6 border-l-0 border-t-0 rounded-br-[3px]'
   };
   return <span className={`${common} ${map[position]}`} />;
 };

--- a/src/components/HelpOverlay.tsx
+++ b/src/components/HelpOverlay.tsx
@@ -10,7 +10,7 @@ const HelpOverlay = ({ open, onClose }: HelpOverlayProps) => {
 
   return createPortal(
     <div className="fixed inset-0 z-30 flex items-center justify-center bg-[#0b0d0f]/80 backdrop-blur-sm">
-      <div className="relative w-[min(640px,90vw)] rounded-[28px] border border-[#d6e3e0]/15 bg-panel/85 p-8 font-mono text-[0.7rem] uppercase tracking-[0.24em] text-[#d6e3e0] shadow-panel">
+      <div className="relative w-[min(640px,90vw)] rounded-[4px] border border-[#d6e3e0]/15 bg-panel/95 p-8 font-mono text-[0.7rem] uppercase tracking-[0.24em] text-[#d6e3e0] shadow-panel">
         <h2 className="mb-6 text-center text-xl font-semibold tracking-[0.36em] text-amber">Console Reference</h2>
         <div className="grid gap-4 text-left text-[0.65rem] uppercase tracking-[0.28em] text-mid">
           <p>Press <span className="text-[#d6e3e0]">C</span> for credentials overlay.</p>

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -23,7 +23,7 @@ const InstallPrompt = () => {
   if (!visible || !promptEvent) return null;
 
   return (
-    <div className="fixed bottom-6 left-1/2 z-30 flex w-[min(420px,90vw)] -translate-x-1/2 items-center justify-between gap-4 rounded-[22px] border border-[#d6e3e0]/15 bg-panel/85 px-5 py-4 font-mono text-[0.62rem] uppercase tracking-[0.28em] text-[#d6e3e0] shadow-panel">
+    <div className="fixed bottom-6 left-1/2 z-30 flex w-[min(420px,90vw)] -translate-x-1/2 items-center justify-between gap-4 rounded-[3px] border border-[#d6e3e0]/15 bg-panel/90 px-5 py-4 font-mono text-[0.62rem] uppercase tracking-[0.28em] text-[#d6e3e0] shadow-panel">
       <span>Install BioArchive Intelligence for offline deployment?</span>
       <div className="flex items-center gap-2">
         <button

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -17,7 +17,7 @@ const Panel = ({ title, sublabel, actions, children, active, variant = 'default'
       id={id}
       data-variant={variant === 'dossier' ? 'dossier' : undefined}
       className={clsx(
-        'relative overflow-hidden rounded-[22px] border border-[#d6e3e0]/10 bg-panel/75 p-5 text-sm shadow-panel transition-all duration-300',
+        'relative overflow-hidden rounded-[3px] border border-[#d6e3e0]/10 bg-panel/80 p-5 text-sm shadow-panel transition-all duration-300',
         active ? 'border-amber/80 shadow-[0_0_32px_rgba(0,179,255,0.25)]' : 'hover:border-amber/40',
         variant === 'dossier' && 'bg-[#0b0d0f]/60 font-mono text-[0.82rem] uppercase tracking-[0.18em] text-mid'
       )}

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -105,7 +105,7 @@ const SearchBox = ({ onSearch }: { onSearch: (term: string) => void }) => {
     <div ref={containerRef} className="relative w-full max-w-xl">
       <form
         onSubmit={handleSubmit}
-        className="flex items-center gap-3 rounded-[28px] border border-[#d6e3e0]/10 bg-[#0b0d0f]/60 px-5 py-3 shadow-panel"
+        className="flex items-center gap-3 rounded-[3px] border border-[#d6e3e0]/10 bg-[#0b0d0f]/70 px-5 py-3 shadow-panel"
       >
         <label className="font-mono text-[0.6rem] uppercase tracking-[0.3em] text-dim" htmlFor="archive-search">
           Query
@@ -137,7 +137,7 @@ const SearchBox = ({ onSearch }: { onSearch: (term: string) => void }) => {
           id={listboxId}
           role="listbox"
           aria-label="Suggested dossiers"
-          className="absolute z-20 mt-2 max-h-72 w-full overflow-auto rounded-[20px] border border-[#d6e3e0]/12 bg-panel/90 backdrop-blur-xl text-left shadow-panel"
+          className="absolute z-20 mt-2 max-h-72 w-full overflow-auto rounded-[3px] border border-[#d6e3e0]/12 bg-panel/95 backdrop-blur-xl text-left shadow-panel"
         >
           {suggestions.map((item, index) => (
             <li

--- a/src/components/TrendMini.tsx
+++ b/src/components/TrendMini.tsx
@@ -5,7 +5,7 @@ const TrendMini = ({ data }: { data: CitationPoint[] }) => {
   const chartData = data.map((entry) => ({ year: entry.y, count: entry.c }));
 
   return (
-    <div className="relative overflow-hidden rounded-[22px] border border-[#d6e3e0]/12 bg-panel/70 p-5 shadow-panel">
+    <div className="relative overflow-hidden rounded-[3px] border border-[#d6e3e0]/12 bg-panel/85 p-5 shadow-panel">
       <header className="mb-3 flex items-center justify-between text-[0.58rem] font-mono uppercase tracking-[0.32em] text-dim">
         <span>Telemetry // Citations</span>
         <span className="text-amber">Live Feed</span>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -77,7 +77,7 @@ const Home = () => {
 
   return (
     <div className="relative z-10 space-y-10">
-      <section className="grid gap-8 rounded-[28px] border border-[#1a1f24]/60 bg-[#10161d]/70 p-6 lg:grid-cols-[1.5fr_1fr] lg:p-8">
+      <section className="grid gap-8 rounded-[3px] border border-[#1a1f24]/60 bg-[#10161d]/85 p-6 lg:grid-cols-[1.5fr_1fr] lg:p-8">
         <div className="space-y-6">
           <header className="space-y-4">
             <p className="font-mono text-[0.64rem] uppercase tracking-[0.28em] text-[#55e6a5]">BioArchive Intelligence</p>
@@ -111,7 +111,7 @@ const Home = () => {
         <Filters {...filterOptions} />
       </section>
 
-      <section className="space-y-4 rounded-[28px] border border-[#1a1f24]/60 bg-[#10161d]/70 p-6 lg:p-8">
+      <section className="space-y-4 rounded-[3px] border border-[#1a1f24]/60 bg-[#10161d]/85 p-6 lg:p-8">
         <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <p className="font-mono text-[0.64rem] uppercase tracking-[0.24em] text-[#55e6a5]">Results</p>
@@ -131,7 +131,7 @@ const Home = () => {
 };
 
 const EmptyState = () => (
-  <div className="flex h-60 flex-col items-center justify-center rounded-[26px] border border-dashed border-[#d6e3e0]/15 bg-[#0b0d0f]/50 text-center">
+  <div className="flex h-60 flex-col items-center justify-center rounded-[3px] border border-dashed border-[#d6e3e0]/15 bg-[#0b0d0f]/60 text-center">
     <p className="font-mono text-[0.68rem] uppercase tracking-[0.24em] text-dim">No dossiers match the current filters.</p>
     <p className="mt-2 font-mono text-[0.62rem] uppercase tracking-[0.22em] text-mid">
       Adjust organism, platform, or mission year to widen the search.

--- a/src/routes/Paper.tsx
+++ b/src/routes/Paper.tsx
@@ -63,7 +63,7 @@ const Paper = () => {
 
   if (query.isError || !query.data) {
     return (
-      <div className="rounded-[22px] border border-red/40 bg-[#0b0d0f]/60 p-6 text-red text-sm">
+      <div className="rounded-[3px] border border-red/40 bg-[#0b0d0f]/70 p-6 text-red text-sm">
         Dossier retrieval failed. <Link className="underline" to="/">Return to archive</Link>
       </div>
     );
@@ -79,7 +79,7 @@ const Paper = () => {
 
   return (
     <div className="space-y-8">
-      <header className="relative overflow-hidden rounded-[28px] border border-[#d6e3e0]/12 bg-panel/80 p-6 shadow-panel">
+      <header className="relative overflow-hidden rounded-[3px] border border-[#d6e3e0]/12 bg-panel/95 p-6 shadow-panel">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="space-y-2">
             <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[#55e6a5]">Dossier {id}</p>
@@ -167,7 +167,7 @@ const Paper = () => {
         </div>
 
         <aside className="space-y-6">
-          <div className="rounded-[24px] border border-[#d6e3e0]/14 bg-panel/80 p-5 shadow-panel">
+          <div className="rounded-[3px] border border-[#d6e3e0]/14 bg-panel/95 p-5 shadow-panel">
             <header className="mb-4 font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#9fb4bc]">Meta</header>
             <dl className="space-y-3 text-[0.82rem]">
               <MetaRow label="Year" value={year.toString()} />

--- a/src/routes/Tactical.tsx
+++ b/src/routes/Tactical.tsx
@@ -3,7 +3,7 @@ import ExclusionMap from '../components/ExclusionMap';
 const Tactical = () => {
   return (
     <div className="space-y-6">
-      <header className="rounded-[28px] border border-[#d6e3e0]/14 bg-panel/85 p-6 shadow-panel">
+      <header className="rounded-[3px] border border-[#d6e3e0]/14 bg-panel/95 p-6 shadow-panel">
         <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[#55e6a5]">Mission Planning</p>
         <h1 className="mt-2 text-3xl font-semibold uppercase tracking-[0.22em] text-[#f3f8f6]">Tactical Map</h1>
         <p className="mt-3 max-w-2xl font-mono text-[0.68rem] uppercase tracking-[0.24em] text-[#9fb4bc]">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,7 +6,7 @@
 
 :root {
   --bg: #0b0d0f;
-  --panel: rgba(16, 22, 29, 0.78);
+  --panel: rgba(12, 17, 23, 0.88);
   --stroke: #1a1f24;
   --grid: #1a1f24;
   --amber: #00b3ff;
@@ -239,7 +239,7 @@ a:focus-visible {
   position: relative;
   width: min(720px, 86vw);
   border: 1px solid var(--stroke);
-  border-radius: 12px;
+  border-radius: 4px;
   background: linear-gradient(180deg, rgba(24, 33, 38, 0.6), rgba(13, 19, 22, 0.6));
   backdrop-filter: blur(3px) saturate(120%);
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05) inset, 0 20px 60px rgba(0, 0, 0, 0.6);
@@ -249,7 +249,7 @@ a:focus-visible {
   content: '';
   position: absolute;
   inset: -1px;
-  border-radius: 12px;
+  border-radius: 4px;
   box-shadow: 0 0 24px 2px rgba(255, 186, 57, 0.25);
   pointer-events: none;
   filter: saturate(120%);
@@ -306,7 +306,7 @@ a:focus-visible {
   border: 1px solid var(--amber);
   color: var(--white);
   background: transparent;
-  border-radius: 8px;
+  border-radius: 3px;
   cursor: pointer;
   transition: transform 0.16s ease, box-shadow 0.16s ease, background-color 0.16s ease;
   box-shadow: 0 0 0 2px rgba(255, 186, 57, 0.1) inset, 0 0 12px rgba(255, 186, 57, 0.15);

--- a/styles.css
+++ b/styles.css
@@ -107,7 +107,7 @@ body {
   background: var(--card-bg);
   border: 1px solid var(--border);
   box-shadow: var(--module-shadow);
-  border-radius: 6px;
+  border-radius: 3px;
   padding: 1.2rem;
   margin-bottom: 1.5rem;
   position: relative;
@@ -151,7 +151,7 @@ input,
 select {
   width: 100%;
   padding: 0.6rem 0.75rem;
-  border-radius: 4px;
+  border-radius: 2px;
   border: 1px solid rgba(0, 255, 255, 0.2);
   background: rgba(2, 14, 20, 0.9);
   color: var(--text);
@@ -178,7 +178,7 @@ select:focus {
   padding: 0.75rem;
   margin-bottom: 0.6rem;
   border: 1px solid rgba(0, 255, 255, 0.15);
-  border-radius: 4px;
+  border-radius: 2px;
   cursor: pointer;
   transition: border-color 0.3s ease, transform 0.3s ease;
 }
@@ -207,7 +207,7 @@ select:focus {
   position: relative;
   padding: 1.5rem;
   border: 1px solid rgba(0, 255, 255, 0.2);
-  border-radius: 10px;
+  border-radius: 3px;
   background: rgba(4, 10, 15, 0.85);
   box-shadow: 0 0 24px rgba(0, 255, 255, 0.2);
   overflow: hidden;
@@ -217,7 +217,7 @@ select:focus {
   text-align: center;
   padding: 1.25rem;
   border: 1px solid rgba(0, 255, 255, 0.3);
-  border-radius: 8px;
+  border-radius: 3px;
   background: rgba(0, 10, 16, 0.75);
   margin-bottom: 1.5rem;
   position: relative;
@@ -357,7 +357,7 @@ select:focus {
 
 ::-webkit-scrollbar-thumb {
   background: rgba(0, 255, 255, 0.3);
-  border-radius: 4px;
+  border-radius: 2px;
 }
 
 ::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
## Summary
- flatten panel, card, and overlay border radii to near-square edges while keeping intentional circular accents
- deepen panel background opacity via the panel color token and related classes for clearer text contrast
- align legacy stylesheet modules with the new sharp geometry treatment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1baaa1f8483298be6542cdf0e1562