### PR TITLE
Improve console typography hierarchy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,29 +87,29 @@ const AppContent = () => {
       <HelpOverlay open={showHelp} onClose={() => setHelp(false)} />
       <CredentialOverlay open={credentialOpen} onClose={() => setCredential(false)} />
       <div className="relative z-10 flex min-h-screen flex-col">
-        <header className="px-6 py-4 border-b border-[#1a1f24]/70 bg-[#10161d]/80 shadow-[0_24px_60px_rgba(0,0,0,0.55)] backdrop-blur-sm">
+        <header className="px-6 py-5 border-b border-[#1a1f24]/70 bg-[#10161d]/85 shadow-[0_24px_60px_rgba(0,0,0,0.55)] backdrop-blur-sm">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-              <div className="relative overflow-hidden rounded-lg border border-[#1f2a33] bg-[#0b1118]/90 px-5 py-3 text-left shadow-[0_0_32px_rgba(9,15,22,0.55)]">
+              <div className="relative overflow-hidden rounded-lg border border-[#26313a] bg-[#0b1118]/95 px-5 py-4 text-left shadow-[0_0_32px_rgba(9,15,22,0.55)]">
                 <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(85,230,165,0.28),_transparent_65%)]" />
-                <div className="relative flex flex-col leading-tight">
-                  <span className="font-mono text-[0.52rem] uppercase tracking-[0.5em] text-[#55e6a5]/70">
+                <div className="relative flex flex-col gap-0.5 leading-tight">
+                  <span className="font-mono text-[0.68rem] uppercase tracking-[0.42em] text-[#55e6a5]/70">
                     Mission Control // A.G-01
                   </span>
-                  <span className="font-semibold uppercase tracking-[0.44em] text-[#f5fbfa] sm:text-[0.95rem]">
+                  <span className="font-semibold uppercase tracking-[0.36em] text-[#f5fbfa] text-[1.05rem] sm:text-[1.15rem]">
                     Astro Genesis
                   </span>
-                  <span className="font-mono text-[0.5rem] uppercase tracking-[0.42em] text-[#f66a4d]">
+                  <span className="font-mono text-[0.66rem] uppercase tracking-[0.38em] text-[#f66a4d]">
                     Bio Intelligence Archive
                   </span>
                 </div>
               </div>
-              <span className="font-mono text-[0.7rem] uppercase tracking-[0.22em] text-[#55e6a5]">
+              <span className="font-mono text-[0.82rem] uppercase tracking-[0.2em] text-[#6ff0b7]">
                 Offline-first classified ops console
               </span>
             </div>
             <div className="flex items-center gap-4">
-              <nav className="flex gap-4 text-[0.68rem] font-mono uppercase tracking-[0.2em] text-[#7a8b94]">
+              <nav className="flex gap-4 text-[0.82rem] font-mono uppercase tracking-[0.18em] text-[#8fa1ac]">
                 <NavLink
                   to="/"
                   className={({ isActive }) =>
@@ -138,7 +138,7 @@ const AppContent = () => {
               </nav>
               <button
                 type="button"
-                className="rounded-full border border-[#1a1f24] bg-[#131d26]/80 px-4 py-1 font-mono text-[0.68rem] uppercase tracking-[0.22em] text-[#7a8b94] shadow-[0_0_22px_rgba(0,0,0,0.45)] transition-colors hover:text-[#d6e3e0]"
+                className="rounded-full border border-[#1a1f24] bg-[#131d26]/85 px-5 py-1.5 font-mono text-[0.82rem] uppercase tracking-[0.18em] text-[#8fa1ac] shadow-[0_0_22px_rgba(0,0,0,0.45)] transition-colors hover:text-[#d6e3e0]"
                 onClick={() => toggleMode()}
               >
                 {mode === 'hud' ? 'Switch to MONO' : 'Switch to HUD'}
@@ -155,7 +155,7 @@ const AppContent = () => {
             </Routes>
           </Suspense>
         </main>
-        <footer className="px-6 py-4 border-t border-[#1a1f24]/70 bg-[#0f141a]/80 text-[0.6rem] font-mono uppercase tracking-[0.22em] text-[#7a8b94]">
+        <footer className="px-6 py-5 border-t border-[#1a1f24]/70 bg-[#0f141a]/85 text-[0.75rem] font-mono uppercase tracking-[0.18em] text-[#90a2ad]">
           Signal integrity nominal // Press C for credentials · Press ? for help overlay
         </footer>
       </div>

--- a/src/components/ActiveFiltersBar.tsx
+++ b/src/components/ActiveFiltersBar.tsx
@@ -28,16 +28,16 @@ const ActiveFiltersBar = () => {
 
   if (entries.length === 0) {
     return (
-      <div className="flex items-center gap-3 rounded-[3px] border border-[#1a1f24]/70 bg-[#0b0d0f]/70 px-4 py-3 font-mono text-[0.58rem] uppercase tracking-[0.3em] text-[#3f525c] shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
-        <span className="text-[#55e6a5]/70">Filters nominal</span>
-        <span>// All dossiers shown</span>
+      <div className="flex items-center gap-4 rounded-[3px] border border-[#1a1f24]/60 bg-[#0b0d0f]/75 px-5 py-3.5 font-mono text-[0.78rem] uppercase tracking-[0.24em] text-[#4d606a] shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
+        <span className="text-[#67f3b5]/80">Filters nominal</span>
+        <span className="text-[#8fa1ac]">// All dossiers shown</span>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-3 rounded-[3px] border border-[#1a1f24]/70 bg-[#0b0d0f]/70 px-4 py-3 shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
-      <span className="font-mono text-[0.58rem] uppercase tracking-[0.3em] text-[#55e6a5]">
+    <div className="flex flex-wrap items-center gap-3 rounded-[3px] border border-[#1a1f24]/60 bg-[#0b0d0f]/75 px-5 py-3.5 shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
+      <span className="font-mono text-[0.78rem] uppercase tracking-[0.24em] text-[#67f3b5]">
         Active Filters
       </span>
       <ul className="flex flex-wrap gap-2">
@@ -46,10 +46,10 @@ const ActiveFiltersBar = () => {
             <button
               type="button"
               onClick={() => handleRemove(entry.key)}
-              className="group flex items-center gap-2 rounded-full border border-amber/50 bg-[#131d26]/70 px-3 py-1 font-mono text-[0.55rem] uppercase tracking-[0.28em] text-amber transition-colors hover:border-amber/80 hover:bg-amber/10 hover:text-[#d6e3e0]"
+              className="group flex items-center gap-2 rounded-full border border-amber/50 bg-[#131d26]/75 px-4 py-1.5 font-mono text-[0.78rem] uppercase tracking-[0.2em] text-amber transition-colors hover:border-amber/80 hover:bg-amber/10 hover:text-[#f1f7f5]"
             >
               <span>{entry.label}</span>
-              <span className="rounded-sm bg-[#0b0d0f]/70 px-1.5 py-0.5 text-[0.55rem] group-hover:bg-amber/20">
+              <span className="rounded-sm bg-[#0b0d0f]/70 px-2 py-0.5 text-[0.72rem] text-[#8fa1ac] group-hover:bg-amber/20 group-hover:text-[#f1f7f5]">
                 {entry.value}
               </span>
               <span className="text-[#d6e3e0]/70 group-hover:text-[#d6e3e0]">×</span>
@@ -60,7 +60,7 @@ const ActiveFiltersBar = () => {
       <button
         type="button"
         onClick={() => resetFilters()}
-        className="ml-auto rounded-full border border-[#1a1f24] bg-[#131d26]/70 px-3 py-1 font-mono text-[0.55rem] uppercase tracking-[0.28em] text-[#7a8b94] transition hover:border-[#55e6a5]/60 hover:text-[#d6e3e0]"
+        className="ml-auto rounded-full border border-[#1a1f24] bg-[#131d26]/80 px-4 py-1.5 font-mono text-[0.78rem] uppercase tracking-[0.2em] text-[#8fa1ac] transition hover:border-[#55e6a5]/60 hover:text-[#f1f7f5]"
       >
         Clear All
       </button>

--- a/src/components/CardStack.tsx
+++ b/src/components/CardStack.tsx
@@ -46,57 +46,57 @@ const StackCard = ({ item, index }: StackCardProps) => {
       onMouseLeave={handleLeave}
     >
       <div
-        className="absolute inset-0 -z-[1] rounded-[4px] border border-[#1a1f24]/50 bg-[#10161d]/75 backdrop-blur-sm transition-transform duration-500 group-hover:-translate-y-2"
+        className="absolute inset-0 -z-[1] rounded-[4px] border border-[#1a1f24]/45 bg-[#10161d]/80 backdrop-blur-sm transition-transform duration-500 group-hover:-translate-y-2"
         style={{ transform: `translate3d(${tilt.x}px, ${tilt.y}px, 0)` }}
       />
       <article
-        className="relative overflow-hidden rounded-[4px] border border-[#1a1f24]/70 bg-[#131d26]/85 p-6 shadow-[0_28px_60px_rgba(0,0,0,0.5)] transition-transform duration-500 group-hover:-translate-y-3"
+        className="relative overflow-hidden rounded-[4px] border border-[#1a1f24]/65 bg-[#131d26]/90 p-7 shadow-[0_28px_60px_rgba(0,0,0,0.5)] transition-transform duration-500 group-hover:-translate-y-3"
         style={{ transform: `translate3d(${tilt.x}px, ${tilt.y}px, 0)` }}
       >
-        <header className="mb-4 space-y-3">
-          <div className="flex items-center justify-between text-[0.55rem] uppercase tracking-[0.28em] text-[#7a8b94]">
+        <header className="mb-6 space-y-4">
+          <div className="flex items-center justify-between text-[0.78rem] uppercase tracking-[0.2em] text-[#8fa1ac]">
             <span>Dossier {index.toString().padStart(3, '0')}</span>
             <span className="font-mono text-[#7a8b94]">ID // {item.id}</span>
           </div>
-          <h2 className="text-lg font-semibold tracking-[0.06em] text-[#d6e3e0]/95 transition-colors group-hover:text-cyan">
+          <h2 className="text-2xl font-semibold tracking-[0.08em] text-[#f1f7f5] transition-colors group-hover:text-cyan">
             {item.title}
           </h2>
-          <p className="font-mono text-[0.62rem] uppercase tracking-[0.28em] text-[#7a8b94]">
+          <p className="font-mono text-[0.82rem] uppercase tracking-[0.2em] text-[#8fa1ac]">
             {item.authors.join(', ')}
           </p>
         </header>
 
-        <dl className="grid grid-cols-3 gap-2 text-[0.6rem] font-mono uppercase tracking-[0.2em] text-[#7a8b94]">
-          <div className="rounded-[3px] border border-[#1a1f24]/70 bg-[#141c24]/80 px-3 py-2">
-            <dt className="text-[0.55rem] text-[#5d6c75]">Year</dt>
-            <dd className="text-[#d6e3e0]">{item.year}</dd>
+        <dl className="grid grid-cols-3 gap-3 text-[0.82rem] font-mono uppercase tracking-[0.18em] text-[#8fa1ac]">
+          <div className="rounded-[3px] border border-[#1a1f24]/60 bg-[#141c24]/85 px-4 py-3">
+            <dt className="text-[0.72rem] text-[#6c7d87]">Year</dt>
+            <dd className="text-[#f1f7f5]">{item.year}</dd>
           </div>
-          <div className="rounded-[3px] border border-[#1a1f24]/70 bg-[#141c24]/80 px-3 py-2">
-            <dt className="text-[0.55rem] text-[#5d6c75]">Organism</dt>
-            <dd className="text-[#d6e3e0] truncate" title={item.organism}>
+          <div className="rounded-[3px] border border-[#1a1f24]/60 bg-[#141c24]/85 px-4 py-3">
+            <dt className="text-[0.72rem] text-[#6c7d87]">Organism</dt>
+            <dd className="text-[#f1f7f5] truncate" title={item.organism}>
               {item.organism}
             </dd>
           </div>
-          <div className="rounded-[3px] border border-[#1a1f24]/70 bg-[#141c24]/80 px-3 py-2">
-            <dt className="text-[0.55rem] text-[#5d6c75]">Platform</dt>
-            <dd className="text-[#d6e3e0] truncate" title={item.platform}>
+          <div className="rounded-[3px] border border-[#1a1f24]/60 bg-[#141c24]/85 px-4 py-3">
+            <dt className="text-[0.72rem] text-[#6c7d87]">Platform</dt>
+            <dd className="text-[#f1f7f5] truncate" title={item.platform}>
               {item.platform}
             </dd>
           </div>
         </dl>
 
-        <div className="mt-4 flex flex-wrap gap-2">
+        <div className="mt-5 flex flex-wrap gap-3">
           {item.keywords.slice(0, 4).map((keyword) => (
             <span
               key={keyword}
-              className="rounded-full border border-[#1a1f24] bg-[#141c24]/70 px-3 py-1 text-[0.55rem] font-mono uppercase tracking-[0.28em] text-[#7a8b94] transition-colors group-hover:border-[#55e6a5]/60 group-hover:text-[#d6e3e0]"
+              className="rounded-full border border-[#1a1f24] bg-[#141c24]/75 px-3.5 py-1.5 text-[0.78rem] font-mono uppercase tracking-[0.18em] text-[#8fa1ac] transition-colors group-hover:border-[#55e6a5]/60 group-hover:text-[#d6e3e0]"
             >
               {keyword}
             </span>
           ))}
         </div>
 
-        <div className="mt-5 flex items-center justify-between">
+        <div className="mt-7 flex items-center justify-between">
           <Battery confidence={item.confidence} />
           <HudBadge label="Entities" tone="cyan" compact value={<span>{item.entities.length}</span>} />
         </div>
@@ -115,17 +115,17 @@ const Battery = ({ confidence }: BatteryProps) => {
   const active = Math.round(confidence * segments);
   return (
     <div className="flex items-center gap-2">
-      <span className="text-[0.55rem] font-mono uppercase tracking-[0.28em] text-[#7a8b94]">Confidence</span>
-      <div className="flex items-center gap-1">
-        <div className="flex gap-1 rounded-[3px] border border-[#1a1f24]/60 bg-[#141c24]/70 px-1 py-1">
+      <span className="text-[0.78rem] font-mono uppercase tracking-[0.2em] text-[#8fa1ac]">Confidence</span>
+      <div className="flex items-center gap-2">
+        <div className="flex gap-1 rounded-[3px] border border-[#1a1f24]/60 bg-[#141c24]/70 px-1.5 py-1.5">
           {Array.from({ length: segments }).map((_, index) => (
             <span
               key={index}
-              className={`h-3 w-2 rounded-sm ${index < active ? 'bg-cyan shadow-[0_0_12px_rgba(85,230,165,0.35)]' : 'bg-[#d6e3e0]/10'}`}
+              className={`h-3.5 w-2.5 rounded-sm ${index < active ? 'bg-cyan shadow-[0_0_12px_rgba(85,230,165,0.35)]' : 'bg-[#d6e3e0]/10'}`}
             />
           ))}
         </div>
-        <span className="font-mono text-[0.6rem] text-[#7a8b94]">{Math.round(confidence * 100)}%</span>
+        <span className="font-mono text-[0.82rem] text-[#8fa1ac]">{Math.round(confidence * 100)}%</span>
       </div>
     </div>
   );

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -22,14 +22,14 @@ const Filters = ({ organisms, platforms, years }: FilterProps) => {
   }));
 
   return (
-    <aside className="rounded-[3px] border border-[#1a1f24]/70 bg-[#10161d]/85 p-6 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+    <aside className="rounded-[3px] border border-[#1a1f24]/60 bg-[#10161d]/92 p-7 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
       <header className="mb-4 flex items-center justify-between">
         <div>
-          <p className="font-mono text-[0.66rem] uppercase tracking-[0.32em] text-[#55e6a5]">Filters</p>
-          <h3 className="text-xl font-semibold tracking-[0.18em] text-[#d6e3e0]">Operational Scope</h3>
+          <p className="font-mono text-[0.78rem] uppercase tracking-[0.24em] text-[#67f3b5]">Filters</p>
+          <h3 className="text-2xl font-semibold tracking-[0.14em] text-[#f1f7f5]">Operational Scope</h3>
         </div>
         <button
-          className="rounded-full border border-[#1a1f24] bg-[#131d26]/80 px-4 py-1.5 font-mono text-[0.6rem] uppercase tracking-[0.3em] text-[#7a8b94] transition hover:border-[#55e6a5]/60 hover:text-[#d6e3e0]"
+          className="rounded-full border border-[#1a1f24] bg-[#131d26]/80 px-5 py-2 font-mono text-[0.82rem] uppercase tracking-[0.2em] text-[#8fa1ac] transition hover:border-[#55e6a5]/60 hover:text-[#d6e3e0]"
           onClick={() => resetFilters()}
           type="button"
         >
@@ -70,7 +70,7 @@ type FilterGroupProps = {
 const FilterGroup = ({ label, options, activeValue, onSelect }: FilterGroupProps) => (
   <div className="space-y-4">
     <div className="flex items-center justify-between">
-      <p className="font-mono text-[0.66rem] uppercase tracking-[0.32em] text-[#7a8b94]">{label}</p>
+      <p className="font-mono text-[0.78rem] uppercase tracking-[0.24em] text-[#8fa1ac]">{label}</p>
       <HudBadge label="Count" tone="cyan" compact value={<span>{options.reduce((acc, option) => acc + option.count, 0)}</span>} />
     </div>
     <div className="flex flex-wrap gap-3">
@@ -79,7 +79,7 @@ const FilterGroup = ({ label, options, activeValue, onSelect }: FilterGroupProps
           key={option.value}
           type="button"
           className={clsx(
-            'group flex items-center gap-2 rounded-full border px-4 py-2 font-mono text-[0.62rem] uppercase tracking-[0.28em] transition-colors duration-200',
+            'group flex items-center gap-2 rounded-full border px-4 py-2 font-mono text-[0.78rem] uppercase tracking-[0.2em] transition-colors duration-200',
             activeValue === option.value
               ? 'border-[#55e6a5]/70 bg-[#142027]/80 text-[#55e6a5] shadow-[0_0_18px_rgba(85,230,165,0.35)]'
               : 'border-[#1a1f24] text-[#7a8b94] hover:border-[#55e6a5]/50 hover:text-[#d6e3e0]'
@@ -87,7 +87,7 @@ const FilterGroup = ({ label, options, activeValue, onSelect }: FilterGroupProps
           onClick={() => onSelect(option.value)}
         >
           <span>{option.label}</span>
-          <span className="rounded-sm bg-[#0b0d0f]/40 px-2 py-0.5 text-[0.6rem] text-[#7a8b94] group-hover:text-[#d6e3e0]">{option.count}</span>
+          <span className="rounded-sm bg-[#0b0d0f]/50 px-2 py-0.5 text-[0.7rem] text-[#8fa1ac] group-hover:text-[#d6e3e0]">{option.count}</span>
         </button>
       ))}
     </div>

--- a/src/components/HudBadge.tsx
+++ b/src/components/HudBadge.tsx
@@ -19,13 +19,13 @@ const HudBadge = ({ label, value, tone = 'amber', compact }: HudBadgeProps) => {
   return (
     <span
       className={clsx(
-        'inline-flex items-center gap-2 rounded-full border px-3 py-1 font-mono text-[0.6rem] uppercase tracking-[0.22em] transition-colors duration-200',
+        'inline-flex items-center gap-2 rounded-full border px-3.5 py-1.5 font-mono text-[0.78rem] uppercase tracking-[0.18em] transition-colors duration-200',
         toneClass[tone],
-        compact ? 'text-[0.55rem] px-2.5 py-1' : null
+        compact ? 'text-[0.68rem] px-3 py-1' : null
       )}
     >
-      <span className="opacity-70">{label}</span>
-      {value ? <span className="text-[0.65rem] font-semibold tracking-[0.18em]">{value}</span> : null}
+      <span className="opacity-80">{label}</span>
+      {value ? <span className="text-[0.82rem] font-semibold tracking-[0.14em]">{value}</span> : null}
     </span>
   );
 };

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -105,9 +105,9 @@ const SearchBox = ({ onSearch }: { onSearch: (term: string) => void }) => {
     <div ref={containerRef} className="relative w-full max-w-xl">
       <form
         onSubmit={handleSubmit}
-        className="flex items-center gap-3 rounded-[3px] border border-[#d6e3e0]/10 bg-[#0b0d0f]/70 px-5 py-3 shadow-panel"
+        className="flex items-center gap-4 rounded-[3px] border border-[#d6e3e0]/18 bg-[#0b0d0f]/75 px-6 py-4 shadow-panel"
       >
-        <label className="font-mono text-[0.6rem] uppercase tracking-[0.3em] text-dim" htmlFor="archive-search">
+        <label className="font-mono text-[0.78rem] uppercase tracking-[0.22em] text-[#8fa1ac]" htmlFor="archive-search">
           Query
         </label>
         <input
@@ -122,12 +122,12 @@ const SearchBox = ({ onSearch }: { onSearch: (term: string) => void }) => {
           aria-expanded={open}
           aria-controls={open ? listboxId : undefined}
           aria-activedescendant={open && activeIndex >= 0 ? `${listboxId}-${suggestions[activeIndex]?.id}` : undefined}
-          className="flex-1 bg-transparent font-mono text-[0.85rem] uppercase tracking-[0.28em] text-[#d6e3e0] placeholder:text-dim focus:outline-none"
+          className="flex-1 bg-transparent font-mono text-[1rem] uppercase tracking-[0.18em] text-[#f1f7f5] placeholder:text-[#8fa1ac] focus:outline-none"
           placeholder="Title / authors / keywords"
         />
         <button
           type="submit"
-          className="rounded-full border border-amber/60 px-4 py-1.5 font-mono text-[0.6rem] uppercase tracking-[0.3em] text-amber hover:bg-amber/10"
+          className="rounded-full border border-amber/60 px-5 py-2 font-mono text-[0.82rem] uppercase tracking-[0.2em] text-amber hover:bg-amber/10"
         >
           Execute
         </button>
@@ -150,16 +150,16 @@ const SearchBox = ({ onSearch }: { onSearch: (term: string) => void }) => {
                 role="option"
                 aria-selected={index === activeIndex}
                 className={
-                  'flex w-full items-center justify-between gap-3 px-4 py-3 font-mono text-[0.62rem] uppercase tracking-[0.26em] transition-colors ' +
+                  'flex w-full items-center justify-between gap-4 px-5 py-3 font-mono text-[0.78rem] uppercase tracking-[0.2em] transition-colors ' +
                   (index === activeIndex
-                    ? 'bg-amber/10 text-[#d6e3e0] shadow-[0_0_18px_rgba(244,159,66,0.22)]'
-                    : 'text-mid hover:bg-amber/10 hover:text-[#d6e3e0]')
+                    ? 'bg-amber/10 text-[#f1f7f5] shadow-[0_0_18px_rgba(244,159,66,0.22)]'
+                    : 'text-[#8fa1ac] hover:bg-amber/10 hover:text-[#f1f7f5]')
                 }
                 onClick={() => handleSuggestionSelect(item.title)}
                 onMouseEnter={() => setActiveIndex(index)}
               >
                 <span className="truncate text-left">{item.title}</span>
-                <span className="text-dim">{item.year || '—'}</span>
+                <span className="text-[#7a8b94]">{item.year || '—'}</span>
               </button>
             </li>
           ))}

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -77,11 +77,11 @@ const Home = () => {
 
   return (
     <div className="relative z-10 space-y-10">
-      <section className="grid gap-8 rounded-[3px] border border-[#1a1f24]/60 bg-[#10161d]/85 p-6 lg:grid-cols-[1.5fr_1fr] lg:p-8">
-        <div className="space-y-6">
-          <header className="space-y-4">
-            <p className="font-mono text-[0.64rem] uppercase tracking-[0.28em] text-[#55e6a5]">BioArchive Intelligence</p>
-            <h1 className="text-4xl font-semibold uppercase tracking-[0.18em] text-[#d6e3e0]">
+      <section className="grid gap-8 rounded-[3px] border border-[#1a1f24]/55 bg-[#10161d]/90 p-7 lg:grid-cols-[1.5fr_1fr] lg:p-10">
+        <div className="space-y-7">
+          <header className="space-y-5">
+            <p className="font-mono text-[0.82rem] uppercase tracking-[0.24em] text-[#67f3b5]">BioArchive Intelligence</p>
+            <h1 className="text-[2.75rem] font-semibold uppercase tracking-[0.14em] text-[#f1f7f5] sm:text-[3rem]">
               Classified Ops Console
             </h1>
             <div className="flex flex-wrap items-center gap-3">
@@ -95,14 +95,14 @@ const Home = () => {
               {indexQuery.isError ? <HudBadge label="Sync" tone="red" value={<span>Failed</span>} /> : null}
             </div>
           </header>
-          <p className="max-w-2xl font-mono text-[0.74rem] uppercase tracking-[0.22em] text-[#7a8b94]">
+          <p className="max-w-2xl font-mono text-[0.92rem] uppercase tracking-[0.18em] text-[#a8bbb6] leading-relaxed">
             Operate the offline-first NASA bioscience archive. Search across mission dossiers, filter by organism, platform, and year, and pivot into branch maps for rapid briefing delivery.
           </p>
-          <div className="space-y-4">
+          <div className="space-y-5">
             <SearchBox onSearch={() => setResults(runSearch(query, filters))} />
             <ActiveFiltersBar />
           </div>
-          <div className="flex items-center gap-3 text-[0.58rem] font-mono uppercase tracking-[0.32em] text-[#7a8b94]">
+          <div className="flex items-center gap-3 text-[0.78rem] font-mono uppercase tracking-[0.22em] text-[#8fa1ac]">
             <span>Need help?</span>
             <kbd className="rounded border border-[#d6e3e0]/25 bg-[#0b1116]/70 px-2 py-1 text-[#d6e3e0]/85">?</kbd>
             <span>Press for console reference</span>
@@ -111,15 +111,15 @@ const Home = () => {
         <Filters {...filterOptions} />
       </section>
 
-      <section className="space-y-4 rounded-[3px] border border-[#1a1f24]/60 bg-[#10161d]/85 p-6 lg:p-8">
+      <section className="space-y-5 rounded-[3px] border border-[#1a1f24]/55 bg-[#10161d]/90 p-7 lg:p-10">
         <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="font-mono text-[0.64rem] uppercase tracking-[0.24em] text-[#55e6a5]">Results</p>
-            <h2 className="text-xl font-semibold tracking-[0.16em] text-[#d6e3e0]">Stacked Dossiers</h2>
+            <p className="font-mono text-[0.78rem] uppercase tracking-[0.22em] text-[#67f3b5]">Results</p>
+            <h2 className="text-3xl font-semibold tracking-[0.12em] text-[#f1f7f5]">Stacked Dossiers</h2>
           </div>
           <Link
             to="/tactical"
-            className="rounded-full border border-[#1a1f24] bg-[#131d26]/70 px-4 py-2 font-mono text-[0.68rem] uppercase tracking-[0.22em] text-[#7a8b94] transition hover:border-[#55e6a5]/60 hover:text-[#d6e3e0]"
+            className="rounded-full border border-[#1a1f24] bg-[#131d26]/80 px-5 py-2 font-mono text-[0.86rem] uppercase tracking-[0.18em] text-[#8fa1ac] transition hover:border-[#55e6a5]/60 hover:text-[#d6e3e0]"
           >
             Tactical map
           </Link>
@@ -131,9 +131,9 @@ const Home = () => {
 };
 
 const EmptyState = () => (
-  <div className="flex h-60 flex-col items-center justify-center rounded-[3px] border border-dashed border-[#d6e3e0]/15 bg-[#0b0d0f]/60 text-center">
-    <p className="font-mono text-[0.68rem] uppercase tracking-[0.24em] text-dim">No dossiers match the current filters.</p>
-    <p className="mt-2 font-mono text-[0.62rem] uppercase tracking-[0.22em] text-mid">
+  <div className="flex h-60 flex-col items-center justify-center rounded-[3px] border border-dashed border-[#d6e3e0]/15 bg-[#0b0d0f]/70 text-center">
+    <p className="font-mono text-[0.86rem] uppercase tracking-[0.2em] text-[#9fb1bc]">No dossiers match the current filters.</p>
+    <p className="mt-3 font-mono text-[0.78rem] uppercase tracking-[0.18em] text-[#7a8b94]">
       Adjust organism, platform, or mission year to widen the search.
     </p>
   </div>


### PR DESCRIPTION
## Summary
- increase navigation and footer typography scale for better readability across the console
- refresh home dashboard, filter controls, and badges with clearer hierarchy and improved color contrast
- update dossier cards and search UI to emphasize critical details with larger, more balanced type sizes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1bfeea0ac8329b6a887c319219498