### PR TITLE
Adjust splash persistence and demo typing behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,8 @@ const App = () => {
   const [entered, setEntered] = useState(() => {
     if (typeof window === 'undefined') return false;
     try {
-      return window.localStorage.getItem(ENTRY_STORAGE_KEY) === 'true';
+      const stored = window.localStorage.getItem(ENTRY_STORAGE_KEY);
+      return stored === '1' || stored === 'true';
     } catch (error) {
       console.warn('Unable to access localStorage', error);
       return false;
@@ -27,7 +28,7 @@ const App = () => {
 
   const handleProceed = useCallback(() => {
     try {
-      window.localStorage.setItem(ENTRY_STORAGE_KEY, 'true');
+      window.localStorage.setItem(ENTRY_STORAGE_KEY, '1');
     } catch (error) {
       console.warn('Unable to persist entry state', error);
     }

--- a/src/components/splash/TerminalLine.tsx
+++ b/src/components/splash/TerminalLine.tsx
@@ -62,11 +62,7 @@ export default function TerminalLine({
       return;
     }
 
-    if (!isDemoActive) {
-      return;
-    }
-
-    if (event.key.length === 1 || event.key === 'Backspace' || event.key === 'Delete') {
+    if (isDemoActive) {
       setDemoActive(false);
     }
   };


### PR DESCRIPTION
## Summary
- persist splash entry state using a numeric flag while still accepting the previous value
- halt the terminal demo typing animation on any keypress aside from Enter so manual input takes over immediately

## Testing
- npm run lint *(fails: missing ESLint configuration in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a39be0548329becbb92f0d63a72e