### PR TITLE
Enhance global console layout accents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,13 +84,19 @@ const AppContent = () => {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-bg text-[var(--white)]">
+      <a
+        href="#main-content"
+        className="skip-link fixed left-4 top-4 z-[999] -translate-y-16 rounded-full border border-[rgba(0,179,255,0.45)] bg-[rgba(8,16,22,0.96)] px-5 py-2 font-meta text-[0.72rem] tracking-[0.24em] text-[color:var(--white)] shadow-[0_18px_40px_rgba(0,0,0,0.45)] transition-all focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-2)] focus-visible:ring-offset-2 focus-visible:ring-offset-[rgba(4,8,12,0.85)] sm:hover:-translate-y-14 sm:hover:opacity-80"
+      >
+        Skip to mission console
+      </a>
       <GridBg />
       <InstallPrompt />
       <HelpOverlay open={showHelp} onClose={() => setHelp(false)} />
       <CredentialOverlay open={credentialOpen} onClose={() => setCredential(false)} />
       <div className="parallax-grid" aria-hidden />
       <div className="relative z-10 flex min-h-screen flex-col">
-        <header className="layered-panel mx-6 mt-6 border border-[rgba(26,31,36,0.6)] bg-[rgba(10,15,20,0.92)] px-6 py-5 text-[var(--white)]">
+        <header className="layered-panel relative mx-6 mt-6 overflow-hidden rounded-2xl border border-[rgba(26,31,36,0.6)] bg-[rgba(10,15,20,0.92)] px-6 py-5 text-[var(--white)] shadow-[0_22px_60px_rgba(0,0,0,0.42)] before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_top,_rgba(0,179,255,0.18),_transparent_58%)] before:opacity-80 after:pointer-events-none after:absolute after:inset-x-6 after:top-0 after:h-px after:bg-gradient-to-r after:from-[rgba(0,179,255,0.35)] after:via-[rgba(85,230,165,0.4)] after:to-[rgba(0,179,255,0.35)]">
           <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
               <Link
@@ -113,45 +119,58 @@ const AppContent = () => {
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-4">
-              <nav className="flex gap-2 font-meta text-[0.78rem] tracking-[0.22em] text-[color:var(--passive)]">
+              <nav className="flex gap-2 font-meta text-[0.78rem] tracking-[0.22em] text-[color:var(--passive)]" aria-label="Primary navigation">
                 <NavLink
                   to="/"
                   className={({ isActive }) =>
-                    `panel-hover rounded-full border px-4 py-1.5 transition-all ${
+                    `panel-hover relative overflow-hidden rounded-full border px-4 py-1.5 transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-2)] ${
                       isActive
-                        ? 'border-[rgba(85,230,165,0.4)] bg-[rgba(20,35,40,0.92)] text-[color:var(--accent-1)] shadow-[0_0_24px_rgba(85,230,165,0.35)]'
-                        : 'border-transparent bg-[rgba(12,18,24,0.6)] hover:border-[rgba(0,179,255,0.35)] hover:text-[color:var(--white)]'
+                        ? 'border-[rgba(85,230,165,0.4)] bg-[rgba(20,35,40,0.92)] text-[color:var(--accent-1)] shadow-[0_0_24px_rgba(85,230,165,0.35)] before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,_rgba(85,230,165,0.2),_transparent_72%)] before:opacity-80 after:absolute after:bottom-0 after:left-1/2 after:h-[2px] after:w-4/5 after:-translate-x-1/2 after:rounded-full after:bg-gradient-to-r after:from-[rgba(85,230,165,0.5)] after:via-[rgba(255,255,255,0.45)] after:to-[rgba(85,230,165,0.5)]'
+                        : 'border-transparent bg-[rgba(12,18,24,0.6)] hover:border-[rgba(0,179,255,0.35)] hover:text-[color:var(--white)] before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,_rgba(0,179,255,0.12),_transparent_75%)] before:opacity-0 before:transition-opacity before:duration-300 hover:before:opacity-100'
                     }`
                   }
                   end
                 >
-                  Dossiers
+                  <span className="relative z-10">Dossiers</span>
                 </NavLink>
                 <NavLink
                   to="/tactical"
                   className={({ isActive }) =>
-                    `panel-hover rounded-full border px-4 py-1.5 transition-all ${
+                    `panel-hover relative overflow-hidden rounded-full border px-4 py-1.5 transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-2)] ${
                       isActive
-                        ? 'border-[rgba(0,179,255,0.4)] bg-[rgba(16,28,36,0.92)] text-[color:var(--accent-2)] shadow-[0_0_24px_rgba(0,179,255,0.35)]'
-                        : 'border-transparent bg-[rgba(12,18,24,0.6)] hover:border-[rgba(85,230,165,0.35)] hover:text-[color:var(--white)]'
+                        ? 'border-[rgba(0,179,255,0.4)] bg-[rgba(16,28,36,0.92)] text-[color:var(--accent-2)] shadow-[0_0_24px_rgba(0,179,255,0.35)] before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,_rgba(0,179,255,0.22),_transparent_72%)] before:opacity-90 after:absolute after:bottom-0 after:left-1/2 after:h-[2px] after:w-4/5 after:-translate-x-1/2 after:rounded-full after:bg-gradient-to-r after:from-[rgba(0,179,255,0.55)] after:via-[rgba(255,255,255,0.35)] after:to-[rgba(0,179,255,0.55)]'
+                        : 'border-transparent bg-[rgba(12,18,24,0.6)] hover:border-[rgba(85,230,165,0.35)] hover:text-[color:var(--white)] before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,_rgba(85,230,165,0.12),_transparent_75%)] before:opacity-0 before:transition-opacity before:duration-300 hover:before:opacity-100'
                     }`
                   }
                 >
-                  Tactical
+                  <span className="relative z-10">Tactical</span>
                 </NavLink>
               </nav>
               <button
                 type="button"
-                className="panel-hover rounded-full border border-[rgba(36,48,58,0.6)] bg-[rgba(15,24,32,0.85)] px-5 py-2 font-meta text-[0.78rem] tracking-[0.22em] text-[color:var(--mid)] transition-colors hover:text-[color:var(--white)]"
+                className="panel-hover relative overflow-hidden rounded-full border border-[rgba(36,48,58,0.6)] bg-[rgba(15,24,32,0.85)] px-5 py-2 font-meta text-[0.78rem] tracking-[0.22em] text-[color:var(--mid)] transition-colors hover:text-[color:var(--white)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-2)]"
                 onClick={() => toggleMode()}
+                aria-pressed={mode === 'mono'}
               >
-                {mode === 'hud' ? 'Switch to Mono' : 'Switch to HUD'}
+                <span className="relative z-10">{mode === 'hud' ? 'Switch to Mono' : 'Switch to HUD'}</span>
+                <span
+                  aria-hidden
+                  className={`pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 ${
+                    mode === 'mono'
+                      ? 'bg-[radial-gradient(circle_at_center,_rgba(85,230,165,0.22),_transparent_70%)] opacity-100'
+                      : 'bg-[radial-gradient(circle_at_center,_rgba(0,179,255,0.18),_transparent_72%)]'
+                  }`}
+                />
               </button>
             </div>
           </div>
         </header>
         <BiosignalPulse className="mx-6 mt-4" />
-        <main className="flex-1 px-6 pb-10 pt-4">
+        <main
+          id="main-content"
+          tabIndex={-1}
+          className="relative flex-1 overflow-hidden rounded-t-3xl border-t border-[rgba(26,31,36,0.55)] bg-[linear-gradient(180deg,rgba(12,18,24,0.85),rgba(10,14,20,0.95))] px-6 pb-10 pt-6 before:pointer-events-none before:absolute before:inset-x-6 before:top-0 before:h-px before:bg-[radial-gradient(circle,_rgba(255,255,255,0.18),_transparent_70%)]"
+        >
           <Suspense fallback={<div className="font-meta animate-pulse text-[color:var(--mid)]">Initializing dossier feed…</div>}>
             <Routes>
               <Route path="/" element={<Home />} />
@@ -160,7 +179,7 @@ const AppContent = () => {
             </Routes>
           </Suspense>
         </main>
-        <footer className="mx-6 mb-6 rounded-xl border border-[rgba(26,31,36,0.55)] bg-[rgba(9,14,18,0.85)] px-6 py-4 font-meta text-[0.72rem] tracking-[0.22em] text-[color:var(--passive)]">
+        <footer className="relative mx-6 mb-6 overflow-hidden rounded-xl border border-[rgba(26,31,36,0.55)] bg-[rgba(9,14,18,0.85)] px-6 py-4 font-meta text-[0.72rem] tracking-[0.22em] text-[color:var(--passive)] before:pointer-events-none before:absolute before:inset-x-6 before:top-0 before:h-px before:bg-gradient-to-r before:from-[rgba(0,179,255,0.28)] before:via-transparent before:to-[rgba(85,230,165,0.3)] after:pointer-events-none after:absolute after:inset-0 after:bg-[radial-gradient(circle_at_bottom,_rgba(0,179,255,0.08),_transparent_70%)]">
           Signal integrity nominal // Press C for credentials · Press ? for help overlay
         </footer>
       </div>


### PR DESCRIPTION
## Summary
- add a prominent skip link and focusable main region to streamline keyboard navigation
- refresh console chrome with layered glow treatments and animated nav highlights without removing content
- improve toggle button feedback and navigation accessibility attributes while preserving existing layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a5d330548329ba1b5a41da9c9be7