### PR TITLE
Increase summarize_jsons batch capacity

### DIFF
--- a/scripts/summarize_jsons.py
+++ b/scripts/summarize_jsons.py
@@ -37,7 +37,7 @@ PROMPT_TEMPLATE = (
 TEMPERATURE = 0.4
 PRIMARY_MODEL = "gpt-4o-mini"
 FALLBACK_MODEL = "gpt-3.5-turbo"
-MAX_BATCH = 2
+MAX_BATCH = 608
 
 
 AI_SUMMARY_KEY = "ai_summary"
@@ -244,8 +244,16 @@ def main() -> None:
     processed_files: List[str] = []
     updates = 0
 
+    if MAX_BATCH:
+        log(
+            "Batch cap enabled: up to %d file(s) will be summarized in this run."
+            % MAX_BATCH
+        )
+    else:
+        log("Batch cap disabled: will attempt to summarize all available files this run.")
+
     for json_path in files:
-        if updates >= MAX_BATCH:
+        if MAX_BATCH and updates >= MAX_BATCH:
             log(
                 "Reached MAX_BATCH=%d limit; remaining files will be processed in a "
                 "future run." % MAX_BATCH


### PR DESCRIPTION
## Summary
- raise the summarization batch cap to 608 items per run
- log whether the batch cap is enabled and only stop iterating when the cap applies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2ab25c71c8329b5bef52358fa7310