### PR TITLE
Refine dossier interface hierarchy and containment

### DIFF
--- a/src/components/BranchMap.tsx
+++ b/src/components/BranchMap.tsx
@@ -26,31 +26,40 @@ const BranchMap = ({ title, activeSection, onSectionChange }: BranchMapProps) =>
   const edges = useMemo<Edge[]>(() => createEdges(layout), [layout]);
 
   return (
-    <div className="relative overflow-hidden rounded-[3px] border border-[#d6e3e0]/10 bg-panel/85 backdrop-blur-sm">
-      <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-between border-b border-[#d6e3e0]/10 bg-[#0b0d0f]/40 px-5 py-3 text-[0.58rem] font-mono uppercase tracking-[0.32em] text-dim">
+    <div className="branch-map-shell">
+      <div className="branch-map-head absolute inset-x-0 top-0 z-10 flex items-center justify-between border-b border-[#d6e3e0]/15 bg-[#0b0d0f]/60 px-5 py-3 text-[0.58rem] font-mono uppercase tracking-[0.32em] text-white/70">
         <span>Branch Map // Narrative Threads</span>
         <div className="flex items-center gap-2">
           <button
             type="button"
-            className={`rounded-full border px-3 py-1 ${layout === 'layered' ? 'border-amber/70 text-amber' : 'border-[#d6e3e0]/20 text-dim hover:text-[#d6e3e0]'}`}
+            className={`rounded-full border px-3 py-1 transition-colors ${
+              layout === 'layered'
+                ? 'border-cyan/60 text-[color:var(--accent-2)] shadow-[0_0_18px_rgba(0,179,255,0.3)]'
+                : 'border-[#d6e3e0]/20 text-white/60 hover:border-cyan/40 hover:text-white/80'
+            }`}
             onClick={() => setLayout('layered')}
           >
             Layered
           </button>
           <button
             type="button"
-            className={`rounded-full border px-3 py-1 ${layout === 'radial' ? 'border-amber/70 text-amber' : 'border-[#d6e3e0]/20 text-dim hover:text-[#d6e3e0]'}`}
+            className={`rounded-full border px-3 py-1 transition-colors ${
+              layout === 'radial'
+                ? 'border-cyan/60 text-[color:var(--accent-2)] shadow-[0_0_18px_rgba(0,179,255,0.3)]'
+                : 'border-[#d6e3e0]/20 text-white/60 hover:border-cyan/40 hover:text-white/80'
+            }`}
             onClick={() => setLayout('radial')}
           >
             Radial
           </button>
         </div>
       </div>
-      <div className="h-[360px] w-full">
+      <div className="branch-map-grid h-[360px] w-full">
         <ReactFlow
           nodes={nodes}
           edges={edges}
           fitView
+          fitViewOptions={{ padding: 0.18 }}
           nodesDraggable={false}
           nodesConnectable={false}
           zoomOnScroll={false}
@@ -64,28 +73,36 @@ const BranchMap = ({ title, activeSection, onSectionChange }: BranchMapProps) =>
               window.location.hash = `#${node.id}`;
             }
           }}
+          className="branch-map-flow"
         >
-          <MiniMap maskColor="rgba(11,13,15,0.85)" nodeColor={() => 'rgba(255,59,59,0.45)'} />
-          <Background color="rgba(214,227,224,0.08)" gap={16} />
-          <Controls showInteractive={false} className="!bg-[#0b0d0f]/70 !border-[#d6e3e0]/10 !text-[#d6e3e0]" />
+          <MiniMap
+            maskColor="rgba(11,13,15,0.82)"
+            nodeColor={() => 'rgba(0,179,255,0.55)'}
+            nodeStrokeColor={() => 'rgba(0,179,255,0.55)'}
+          />
+          <Background color="rgba(85,230,165,0.18)" gap={28} size={1} />
+          <Controls showInteractive={false} className="!bg-[#0b0d0f]/80 !border-[#d6e3e0]/18 !text-[#d6e3e0]" />
         </ReactFlow>
       </div>
+      <div className="branch-map-vignette" aria-hidden="true" />
     </div>
   );
 };
 
 const createNodes = (title: string, activeSection: BranchKey, layout: 'layered' | 'radial'): Node[] => {
   const baseStyle = (active: boolean): React.CSSProperties => ({
-    border: `1px solid ${active ? 'rgba(0,179,255,0.75)' : 'rgba(214,227,224,0.18)'}`,
+    border: `1px solid ${active ? 'rgba(0,179,255,0.9)' : 'rgba(214,227,224,0.22)'}`,
     borderRadius: 18,
-    padding: '10px 14px',
+    padding: '12px 16px',
     fontSize: 11,
     letterSpacing: '0.26em',
     textTransform: 'uppercase',
-    background: active ? 'rgba(16,22,29,0.92)' : 'rgba(11,15,19,0.7)',
-    color: active ? 'var(--amber)' : 'var(--mid)',
-    boxShadow: active ? '0 0 24px rgba(0,179,255,0.3)' : '0 0 12px rgba(0,0,0,0.35)',
-    backdropFilter: 'blur(6px)',
+    background: active ? 'linear-gradient(180deg, rgba(14,22,30,0.95), rgba(10,14,20,0.7))' : 'rgba(11,15,19,0.65)',
+    color: active ? 'rgba(244,252,251,0.95)' : 'rgba(214,227,224,0.78)',
+    boxShadow: active
+      ? '0 0 28px rgba(0,179,255,0.35), inset 0 0 16px rgba(0,179,255,0.25)'
+      : '0 0 18px rgba(0,0,0,0.4)',
+    backdropFilter: 'blur(10px)',
     cursor: 'pointer'
   });
 
@@ -99,15 +116,15 @@ const createNodes = (title: string, activeSection: BranchKey, layout: 'layered' 
       draggable: false,
       type: 'default',
       style: {
-        border: '1px solid rgba(255,59,59,0.65)',
+        border: '1px solid rgba(255,59,59,0.55)',
         borderRadius: 22,
-        padding: '14px 20px',
-        background: 'rgba(16,22,29,0.92)',
-        color: 'var(--white)',
+        padding: '16px 22px',
+        background: 'linear-gradient(180deg, rgba(16,22,29,0.96), rgba(10,14,20,0.75))',
+        color: 'rgba(244,252,251,0.98)',
         fontSize: 13,
         letterSpacing: '0.18em',
         textTransform: 'uppercase',
-        boxShadow: '0 0 32px rgba(255,59,59,0.25)',
+        boxShadow: '0 0 38px rgba(255,59,59,0.35)',
         textAlign: 'center',
         maxWidth: 280
       }
@@ -156,7 +173,7 @@ const radialPositions = {
 };
 
 const createEdges = (layout: 'layered' | 'radial'): Edge[] => {
-  const stroke = layout === 'radial' ? 'rgba(255,59,59,0.7)' : 'rgba(0,179,255,0.7)';
+  const stroke = layout === 'radial' ? 'rgba(255,86,86,0.7)' : 'rgba(0,179,255,0.75)';
   return [
     edge('root', 'abstract', stroke),
     edge('root', 'methods', stroke),
@@ -170,12 +187,14 @@ const edge = (source: string, target: string, stroke: string): Edge => ({
   source,
   target,
   animated: true,
+  type: 'smoothstep',
   style: {
     stroke,
-    strokeWidth: 1.5,
-    strokeDasharray: '6 6'
+    strokeWidth: 2,
+    strokeLinecap: 'round',
+    filter: 'drop-shadow(0 0 12px rgba(0,179,255,0.35))'
   },
-  className: 'animated-edge'
+  className: 'branch-map-edge'
 });
 
 const isBranch = (id: string): id is BranchKey =>

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -16,24 +16,33 @@ const Panel = ({ title, sublabel, actions, children, active, variant = 'default'
     <section
       id={id}
       data-variant={variant === 'dossier' ? 'dossier' : undefined}
+      data-active={active ? '' : undefined}
       className={clsx(
-        'relative overflow-hidden rounded-[3px] border border-[#d6e3e0]/10 bg-panel/80 p-5 text-sm shadow-panel transition-all duration-300',
-        active ? 'border-amber/80 shadow-[0_0_32px_rgba(0,179,255,0.25)]' : 'hover:border-amber/40',
-        variant === 'dossier' && 'bg-[#0b0d0f]/60 font-mono text-[0.82rem] uppercase tracking-[0.18em] text-mid'
+        'relative overflow-hidden rounded-[3px] border border-[#d6e3e0]/12 bg-panel/80 p-5 text-sm shadow-panel transition-all duration-300',
+        active
+          ? 'border-cyan/60 shadow-[0_0_42px_rgba(0,179,255,0.28)] backdrop-blur-md'
+          : 'hover:border-cyan/45 hover:shadow-[0_0_30px_rgba(0,179,255,0.18)]',
+        variant === 'dossier' &&
+          'bg-[#0b0d0f]/70 font-body text-[0.92rem] tracking-[0.06em] text-white/70 [--panel-accent:rgba(0,179,255,0.55)]'
       )}
     >
       <header className="mb-4 flex items-start justify-between gap-3">
         <div className="space-y-1">
-          <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-dim">{sublabel ?? 'Module'}</p>
-          <h3 className="text-base font-semibold tracking-[0.18em] text-[#d6e3e0]">{title}</h3>
+          <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-white/70">{sublabel ?? 'Module'}</p>
+          <h3 className="text-base font-semibold tracking-[0.2em] text-white">{title}</h3>
         </div>
         {actions ? <div className="flex shrink-0 items-center gap-2 text-[0.6rem] text-dim">{actions}</div> : null}
       </header>
-      <div className={clsx('space-y-3 text-[0.92rem] leading-relaxed text-[#d6e3e0]/85', variant === 'dossier' && 'text-[0.65rem] leading-relaxed text-[#d6e3e0]/70')}>
+      <div
+        className={clsx(
+          'space-y-3 text-[0.92rem] leading-relaxed text-white/80',
+          variant === 'dossier' && 'space-y-4 text-[0.95rem] leading-[1.85] text-white/70'
+        )}
+      >
         {children}
       </div>
       <div className="pointer-events-none absolute inset-0 border border-dashed border-[#d6e3e0]/5" />
-      <div className="pointer-events-none absolute -left-10 top-10 h-20 w-20 rounded-full border border-amber/30 opacity-30" />
+      <div className="pointer-events-none absolute -left-10 top-10 h-20 w-20 rounded-full border border-[color:var(--panel-accent,rgba(255,59,59,0.35))]/40 opacity-30" />
       <div className="pointer-events-none absolute right-6 top-6 h-6 w-6 border border-[#d6e3e0]/20" />
     </section>
   );

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -42,8 +42,8 @@ const Panel = ({ title, sublabel, actions, children, active, variant = 'default'
         {children}
       </div>
       <div className="pointer-events-none absolute inset-0 border border-dashed border-[#d6e3e0]/5" />
-      <div className="pointer-events-none absolute -left-10 top-10 h-20 w-20 rounded-full border border-[color:var(--panel-accent,rgba(255,59,59,0.35))]/40 opacity-30" />
-      <div className="pointer-events-none absolute right-6 top-6 h-6 w-6 border border-[#d6e3e0]/20" />
+      <div className="pointer-events-none absolute -left-10 top-10 h-20 w-20 rounded-full border border-[color:var(--panel-accent,rgba(255,59,59,0.35))]/30 opacity-[0.18]" />
+      <div className="pointer-events-none absolute right-6 top-6 h-6 w-6 border border-[#d6e3e0]/12" />
     </section>
   );
 };

--- a/src/components/fui/HudBadge.tsx
+++ b/src/components/fui/HudBadge.tsx
@@ -13,6 +13,7 @@ type HudBadgeProps = {
   pressed?: boolean;
   onClick?: MouseEventHandler<HTMLButtonElement>;
   className?: string;
+  tooltip?: string;
 };
 
 const toneClass: Record<Tone, string> = {
@@ -27,7 +28,7 @@ const toneClass: Record<Tone, string> = {
 };
 
 const HudBadge = forwardRef<HTMLButtonElement, HudBadgeProps>(
-  ({ id, label, value, tone = 'amber', compact, pressed, onClick, className }, ref) => {
+  ({ id, label, value, tone = 'amber', compact, pressed, onClick, className, tooltip }, ref) => {
     const interactive = typeof onClick === 'function';
     return (
       <button
@@ -43,6 +44,7 @@ const HudBadge = forwardRef<HTMLButtonElement, HudBadgeProps>(
           className
         )}
         onClick={onClick}
+        title={tooltip}
         aria-pressed={typeof pressed === 'boolean' ? pressed : undefined}
         aria-disabled={interactive ? undefined : true}
         tabIndex={interactive ? undefined : -1}

--- a/src/routes/Paper.tsx
+++ b/src/routes/Paper.tsx
@@ -131,13 +131,20 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
   const { title, sections, authors, year, organism, platform, keywords, links, access, citations_by_year, confidence, entities } = paper;
 
   return (
-    <div className="space-y-8">
-      <header className="relative overflow-hidden rounded-[3px] border border-[#d6e3e0]/12 bg-panel/95 p-6 shadow-panel">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div className="space-y-2">
-            <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[#55e6a5]">Dossier {dossierId}</p>
-            <h1 className="text-3xl font-semibold uppercase tracking-[0.22em] text-[#f3f8f6]">{title}</h1>
-            <p className="font-mono text-[0.62rem] uppercase tracking-[0.24em] text-[#9fb4bc]">{authors.join(', ')}</p>
+    <div className="space-y-8 transmission-field">
+      <header className="relative overflow-hidden rounded-[12px] border border-[#d6e3e0]/16 bg-[rgba(12,18,24,0.86)] p-6 shadow-[0_30px_70px_rgba(0,0,0,0.42)]">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(0,179,255,0.18),transparent_55%)] opacity-70 mix-blend-screen" aria-hidden="true" />
+        <div className="flex flex-wrap items-start justify-between gap-6">
+          <div className="space-y-3">
+            <p className="font-mono text-[0.58rem] uppercase tracking-[0.32em] text-[rgba(85,230,165,0.8)]">Dossier {dossierId}</p>
+            <h1 className="text-3xl font-semibold uppercase tracking-[0.22em] text-white">{title}</h1>
+            <p className="font-mono text-[0.62rem] tracking-[0.12em] text-white/70">{authors.join(', ')}</p>
+            {data.isFallback ? (
+              <div className="signal-indicator mt-2 inline-flex items-center gap-3 rounded-full border border-amber/40 bg-[rgba(20,16,16,0.55)] px-4 py-2 text-xs font-mono uppercase tracking-[0.22em] text-amber/80">
+                <span className="signal-indicator__dot" aria-hidden="true" />
+                Signal lost — degraded transmission
+              </div>
+            ) : null}
           </div>
           <PcbHeader
             className="ml-auto"
@@ -155,7 +162,7 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
         </div>
       </header>
 
-      <div className="grid gap-8 lg:grid-cols-[1.6fr_1fr]">
+      <div className="grid gap-8 lg:grid-cols-[1.65fr_1fr]">
         <div className="space-y-6">
           <CornerBracket radius={10} size={24} offset={12} color="cyan" glow>
             <div className="relative">
@@ -166,7 +173,7 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
                 padding={18}
                 color="cyan"
                 showCompass
-                className="absolute inset-0"
+                className="absolute inset-0 opacity-60"
               >
                 <span className="text-[0.55rem] tracking-[0.28em] text-[rgba(85,230,165,0.8)]">BRANCH MAP</span>
               </ReticleOverlay>
@@ -174,11 +181,11 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
             </div>
           </CornerBracket>
 
-          <div className="flex flex-wrap items-center gap-3">
-            <FuiBadge id="b-abs" label="ABSTRACT" tone="cyan" size="sm" anchors={['bottom']} />
-            <FuiBadge id="b-met" label="METHODS" tone="cyan" size="sm" anchors={['bottom']} />
-            <FuiBadge id="b-res" label="RESULTS" tone="cyan" size="sm" anchors={['bottom']} />
-            <FuiBadge id="b-con" label="CONCLUSION" tone="cyan" size="sm" anchors={['bottom']} />
+          <div className="flex flex-wrap items-center gap-3 text-white/80">
+            <FuiBadge id="b-abs" label="Abstract" tone="cyan" size="sm" anchors={['bottom']} />
+            <FuiBadge id="b-met" label="Methods" tone="cyan" size="sm" anchors={['bottom']} />
+            <FuiBadge id="b-res" label="Results" tone="cyan" size="sm" anchors={['bottom']} />
+            <FuiBadge id="b-con" label="Conclusion" tone="cyan" size="sm" anchors={['bottom']} />
           </div>
 
           <div className="grid gap-4 md:grid-cols-2">
@@ -267,58 +274,62 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
           </Panel>
         </div>
 
-        <aside className="space-y-6">
-          <div className="rounded-[3px] border border-[#d6e3e0]/14 bg-panel/95 p-5 shadow-panel">
-            <header className="mb-4 font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#9fb4bc]">Meta</header>
-            <dl className="space-y-3 text-[0.82rem]">
+        <aside className="dossier-aside space-y-6">
+          <div className="dossier-meta">
+            <header className="meta-heading">Meta</header>
+            <dl className="meta-grid">
               <MetaRow label="Year" value={year.toString()} />
               <MetaRow label="Organism" value={organism} />
               <MetaRow label="Platform" value={platform} />
             </dl>
-            <div className="mt-4 space-y-2">
-              <p className="font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#5f6c75]">Access Flags</p>
-              <div className="flex flex-wrap gap-2">
+            <div className="meta-section">
+              <p className="meta-label">Access Flags</p>
+              <div className="meta-tags">
                 {access.map((flag) => (
-                  <HudBadge key={flag} label={flag} tone="red" compact />
+                  <HudBadge
+                    key={flag}
+                    label={flag}
+                    tone="red"
+                    compact
+                    className="!border-[rgba(255,86,86,0.6)] !text-[rgba(255,142,142,0.92)]"
+                    tooltip={`Classification flag: ${flag}`}
+                  />
                 ))}
               </div>
             </div>
-            <div className="mt-5 space-y-2">
-              <p className="font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#5f6c75]">Keywords</p>
-              <div className="flex flex-wrap gap-2">
+            <div className="meta-section">
+              <p className="meta-label">Keywords</p>
+              <div className="meta-tags">
                 {keywords.map((keyword) => (
-                  <span
-                    key={keyword}
-                    className="rounded-full border border-[#d6e3e0]/15 bg-[#0b0d0f]/40 px-3 py-1 font-mono text-[0.55rem] uppercase tracking-[0.28em] text-mid"
-                  >
+                  <span key={keyword} className="meta-tag" title={`Related topic: ${keyword}`}>
                     {keyword}
                   </span>
                 ))}
               </div>
             </div>
-            <div className="mt-5 space-y-2">
-              <p className="font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#5f6c75]">Entities</p>
-              <ul className="grid gap-2 text-[0.62rem] font-mono uppercase tracking-[0.28em] text-mid">
+            <div className="meta-section">
+              <p className="meta-label">Entities</p>
+              <ul className="meta-entities">
                 {entities.map((entity) => (
-                  <li key={entity} className="rounded border border-[#d6e3e0]/10 bg-[#0b0d0f]/30 px-3 py-2">
+                  <li key={entity} title={`Referenced entity: ${entity}`}>
                     {entity}
                   </li>
                 ))}
               </ul>
             </div>
-            <div className="mt-5 space-y-2">
-              <p className="font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#5f6c75]">External Links</p>
-              <ul className="space-y-2 text-[0.62rem] font-mono uppercase tracking-[0.28em] text-amber">
+            <div className="meta-section">
+              <p className="meta-label">External Links</p>
+              <ul className="meta-links">
                 {links.taskbook ? (
                   <li>
-                    <a className="hover:text-[#d6e3e0]" href={links.taskbook} target="_blank" rel="noreferrer">
+                    <a className="hover:text-white" href={links.taskbook} target="_blank" rel="noreferrer">
                       Taskbook dossier
                     </a>
                   </li>
                 ) : null}
                 {links.osdr ? (
                   <li>
-                    <a className="hover:text-[#d6e3e0]" href={links.osdr} target="_blank" rel="noreferrer">
+                    <a className="hover:text-white" href={links.osdr} target="_blank" rel="noreferrer">
                       OSDR record
                     </a>
                   </li>
@@ -337,9 +348,9 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
 };
 
 const MetaRow = ({ label, value }: { label: string; value: string }) => (
-  <div className="flex items-center justify-between border-b border-[#d6e3e0]/10 pb-2 last:border-none last:pb-0">
-    <span className="font-mono text-[0.58rem] uppercase tracking-[0.28em] text-[#5f6c75]">{label}</span>
-    <span className="text-sm font-medium text-[#f3f8f6]">{value}</span>
+  <div className="meta-row">
+    <dt className="meta-row__label">{label}</dt>
+    <dd className="meta-row__value">{value}</dd>
   </div>
 );
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -131,6 +131,47 @@ a:focus-visible {
     box-shadow: 0 0 0 1px rgba(0, 179, 255, 0.35), 0 0 24px rgba(85, 230, 165, 0.25);
   }
 
+  .transmission-field {
+    position: relative;
+    isolation: isolate;
+  }
+
+  .transmission-field::before {
+    content: '';
+    position: absolute;
+    inset: -24px -32px;
+    background-image:
+      linear-gradient(rgba(214, 227, 224, 0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(214, 227, 224, 0.05) 1px, transparent 1px);
+    background-size: 56px 56px;
+    opacity: 0.18;
+    pointer-events: none;
+    mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.35));
+  }
+
+  .transmission-field::after {
+    content: '';
+    position: absolute;
+    inset: -120% 0;
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      rgba(0, 179, 255, 0.08) 45%,
+      rgba(0, 179, 255, 0.26) 50%,
+      rgba(0, 179, 255, 0.08) 55%,
+      transparent 100%
+    );
+    animation: dossier-scanline 14s linear infinite;
+    mix-blend-mode: screen;
+    opacity: 0.22;
+    pointer-events: none;
+  }
+
+  .transmission-field > * {
+    position: relative;
+    z-index: 1;
+  }
+
   .mono-grid {
     background-image: linear-gradient(rgba(214, 227, 224, 0.05) 1px, transparent 1px),
       linear-gradient(90deg, rgba(214, 227, 224, 0.05) 1px, transparent 1px);
@@ -193,6 +234,292 @@ a:focus-visible {
     border-radius: 999px;
     background: var(--accent-1);
     box-shadow: 0 0 16px rgba(85, 230, 165, 0.75);
+  }
+
+  .branch-map-shell {
+    position: relative;
+    overflow: hidden;
+    border-radius: 14px;
+    border: 1px solid rgba(0, 179, 255, 0.2);
+    background: linear-gradient(180deg, rgba(8, 12, 16, 0.92), rgba(8, 12, 16, 0.76));
+    box-shadow: 0 28px 60px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(12px);
+  }
+
+  .branch-map-shell::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at 18% 24%, rgba(0, 179, 255, 0.2), transparent 55%),
+      radial-gradient(circle at 82% 78%, rgba(85, 230, 165, 0.18), transparent 60%);
+    opacity: 0.45;
+    pointer-events: none;
+    mix-blend-mode: screen;
+  }
+
+  .branch-map-shell::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle, rgba(0, 0, 0, 0) 45%, rgba(0, 0, 0, 0.6) 100%);
+    pointer-events: none;
+  }
+
+  .branch-map-grid::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(rgba(85, 230, 165, 0.08) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(85, 230, 165, 0.08) 1px, transparent 1px);
+    background-size: 48px 48px;
+    opacity: 0.22;
+    animation: branch-grid-pulse 16s ease-in-out infinite;
+    pointer-events: none;
+  }
+
+  .branch-map-grid {
+    position: relative;
+  }
+
+  .branch-map-flow {
+    background: transparent !important;
+  }
+
+  .branch-map-head {
+    backdrop-filter: blur(6px);
+    z-index: 3;
+  }
+
+  .branch-map-vignette {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    border-radius: inherit;
+    box-shadow: inset 0 0 0 1px rgba(0, 179, 255, 0.22);
+  }
+
+  .branch-map-edge path {
+    stroke-linecap: round;
+  }
+
+  .dossier-aside {
+    position: relative;
+  }
+
+  .dossier-aside::before {
+    content: '';
+    position: absolute;
+    inset: -32px 0 -32px auto;
+    width: 180px;
+    pointer-events: none;
+    background: linear-gradient(90deg, rgba(11, 13, 15, 0), rgba(11, 13, 15, 0.75));
+    opacity: 0.6;
+    transform: translateX(60%);
+  }
+
+  .dossier-meta {
+    position: relative;
+    overflow: hidden;
+    border-radius: 16px;
+    border: 1px solid rgba(85, 230, 165, 0.3);
+    background: linear-gradient(180deg, rgba(9, 14, 20, 0.85), rgba(9, 14, 20, 0.6));
+    padding: 24px;
+    box-shadow: 0 26px 58px rgba(0, 0, 0, 0.42);
+  }
+
+  .dossier-meta::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background:
+      linear-gradient(135deg, rgba(0, 179, 255, 0.12), transparent 55%),
+      linear-gradient(315deg, rgba(85, 230, 165, 0.1), transparent 55%);
+    opacity: 0.6;
+    mix-blend-mode: screen;
+    pointer-events: none;
+  }
+
+  .dossier-meta::after {
+    content: '';
+    position: absolute;
+    inset: 1px;
+    border-radius: inherit;
+    border: 1px dashed rgba(85, 230, 165, 0.16);
+    mask-image: linear-gradient(90deg, rgba(0, 0, 0, 0.25) 0, rgba(0, 0, 0, 1) 15%, rgba(0, 0, 0, 1) 85%, rgba(0, 0, 0, 0.25) 100%);
+    pointer-events: none;
+  }
+
+  .meta-heading {
+    margin-bottom: 1.25rem;
+    font-family: var(--font-meta);
+    font-size: 0.68rem;
+    letter-spacing: 0.26em;
+    text-transform: uppercase;
+    color: rgba(214, 227, 224, 0.78);
+  }
+
+  .meta-grid {
+    display: grid;
+    row-gap: 0.85rem;
+  }
+
+  .meta-row {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: baseline;
+    gap: 1.25rem;
+    padding-bottom: 0.85rem;
+  }
+
+  .meta-row::after {
+    content: '';
+    position: absolute;
+    inset-inline: 0;
+    bottom: 0;
+    height: 1px;
+    background: linear-gradient(90deg, rgba(85, 230, 165, 0), rgba(85, 230, 165, 0.35), rgba(85, 230, 165, 0));
+  }
+
+  .meta-row:last-child {
+    padding-bottom: 0;
+  }
+
+  .meta-row:last-child::after {
+    display: none;
+  }
+
+  .meta-row__label {
+    font-family: var(--font-meta);
+    font-size: 0.62rem;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: rgba(214, 227, 224, 0.78);
+    margin: 0;
+  }
+
+  .meta-row__value {
+    justify-self: end;
+    font-size: 0.92rem;
+    font-weight: 600;
+    color: rgba(244, 252, 251, 0.95);
+    margin: 0;
+  }
+
+  .meta-section {
+    margin-top: 1.8rem;
+  }
+
+  .meta-label {
+    margin-bottom: 0.6rem;
+    font-family: var(--font-meta);
+    font-size: 0.6rem;
+    letter-spacing: 0.26em;
+    text-transform: uppercase;
+    color: rgba(214, 227, 224, 0.72);
+  }
+
+  .meta-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+  }
+
+  .meta-tag {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.5rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid rgba(85, 230, 165, 0.25);
+    background: rgba(9, 14, 20, 0.6);
+    font-family: var(--font-meta);
+    font-size: 0.58rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(244, 252, 251, 0.72);
+    box-shadow: 0 0 16px rgba(85, 230, 165, 0.12);
+  }
+
+  .meta-entities {
+    display: grid;
+    gap: 0.65rem;
+    font-family: var(--font-meta);
+    font-size: 0.58rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: rgba(214, 227, 224, 0.72);
+  }
+
+  .meta-entities li {
+    padding: 0.6rem 0.9rem;
+    border-radius: 10px;
+    border: 1px solid rgba(214, 227, 224, 0.18);
+    background: rgba(11, 16, 22, 0.6);
+    box-shadow: inset 0 0 12px rgba(0, 179, 255, 0.12);
+  }
+
+  .meta-links {
+    display: grid;
+    gap: 0.55rem;
+    font-family: var(--font-meta);
+    font-size: 0.6rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(255, 195, 125, 0.88);
+  }
+
+  .meta-links a {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .meta-links a::after {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: currentColor;
+    box-shadow: 0 0 12px currentColor;
+  }
+
+  .meta-tags .hud-badge--static {
+    cursor: help;
+  }
+
+  .signal-indicator {
+    position: relative;
+    padding-left: 2.5rem;
+  }
+
+  .signal-indicator__dot {
+    position: absolute;
+    left: 1.1rem;
+    top: 50%;
+    width: 8px;
+    height: 8px;
+    transform: translate(-50%, -50%);
+    border-radius: 999px;
+    background: rgba(255, 142, 142, 0.95);
+    box-shadow: 0 0 16px rgba(255, 142, 142, 0.7);
+  }
+
+  .signal-indicator__dot::after {
+    content: '';
+    position: absolute;
+    inset: -4px;
+    border-radius: inherit;
+    border: 1px solid rgba(255, 142, 142, 0.5);
+    animation: signal-ping 2.6s ease-out infinite;
+  }
+
+  .meta-tags .hud-badge {
+    cursor: help;
   }
 
   .pulse-line {
@@ -371,6 +698,42 @@ a:focus-visible {
   .search-console__cta:focus-visible {
     outline: 2px solid rgba(0, 179, 255, 0.7);
     outline-offset: 3px;
+  }
+}
+
+@keyframes dossier-scanline {
+  0% {
+    transform: translateY(-45%);
+  }
+  100% {
+    transform: translateY(45%);
+  }
+}
+
+@keyframes branch-grid-pulse {
+  0%,
+  100% {
+    opacity: 0.18;
+  }
+  45% {
+    opacity: 0.36;
+  }
+  55% {
+    opacity: 0.22;
+  }
+}
+
+@keyframes signal-ping {
+  0% {
+    transform: scale(0.6);
+    opacity: 0.9;
+  }
+  70% {
+    transform: scale(2);
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- brighten dossier header hierarchy and add degraded-signal indicator for fallback data
- restyle dossier panels and metadata card with higher-contrast grid, tooltips, and ambient animation
- refresh branch map framing with contained grid, smooth edges, and glowing controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2ab1ddf688329bfeb9e380a5fa9d4