### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,7 @@ const AppContent = () => {
   }, [location.pathname]);
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-bg text-[var(--white)]">
+    <div className="relative min-h-screen overflow-x-hidden bg-bg text-[var(--white)]">
       <GridBg />
       <InstallPrompt />
       <HelpOverlay open={showHelp} onClose={() => setHelp(false)} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -52,6 +52,12 @@ body {
   overflow-x: hidden;
 }
 
+@media (max-width: 768px) {
+  body {
+    background-attachment: scroll;
+  }
+}
+
 a {
   color: inherit;
 }

--- a/styles.css
+++ b/styles.css
@@ -336,6 +336,8 @@ select:focus {
 @media (max-width: 900px) {
   .layout {
     grid-template-columns: 1fr;
+    gap: 1.25rem;
+    padding: 1.75rem 1.5rem 2.25rem;
   }
 
   .metadata {
@@ -344,6 +346,80 @@ select:focus {
 
   .footer {
     padding: 0 1.5rem 2rem;
+  }
+
+  .main-panel {
+    padding: 1.25rem;
+  }
+
+  .module {
+    padding: 1rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .top-header {
+    padding: 1.25rem 1.1rem;
+    text-align: left;
+  }
+
+  .top-header h1 {
+    font-size: 1.25rem;
+    letter-spacing: 0.16rem;
+  }
+
+  .top-header p {
+    font-size: 0.78rem;
+    letter-spacing: 0.18rem;
+  }
+
+  .layout {
+    gap: 1rem;
+    padding: 1.5rem 1rem 1.75rem;
+  }
+
+  .data-modules {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .main-panel {
+    padding: 1.1rem;
+  }
+
+  .module {
+    padding: 0.95rem;
+  }
+
+  .footer {
+    gap: 1.1rem;
+    padding: 0 1rem 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .top-header {
+    padding: 1.1rem 0.85rem;
+  }
+
+  .top-header h1 {
+    font-size: 1.15rem;
+    letter-spacing: 0.14rem;
+  }
+
+  .layout {
+    padding: 1.25rem 0.75rem 1.5rem;
+  }
+
+  .main-panel {
+    padding: 1rem;
+  }
+
+  .module {
+    padding: 0.9rem;
+  }
+
+  .footer {
+    padding: 0 0.85rem 1.4rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- relax top-level overflow handling to avoid clipping vertical scroll on mobile
- tune splash background attachment for small screens to reduce scrolling jank
- refine legacy layout spacing with mobile-specific padding and typography adjustments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2b76303ec83299939caf927d09722