### PR TITLE
Skip regeneration of existing PMC dossiers

### DIFF
--- a/notes.txt
+++ b/notes.txt
@@ -8,7 +8,7 @@ Run the script:
 python scripts/pmc_ingest.py --limit 5
 
 Use --limit 5 for a small test.
-Add --force to re-download articles if needed.
+Add --force to re-download articles and regenerate dossiers if needed.
 
 Check your outputs:
 data/raw_pmc/ → HTML copies

--- a/scripts/pmc_ingest.py
+++ b/scripts/pmc_ingest.py
@@ -666,6 +666,16 @@ def ingest(
         if not pmcid:
             logger.warning("Skipping row %d: no PMCID detected", idx)
             continue
+        record_id = f"exp_{idx:03d}"
+        existing_json = json_dir / f"{record_id}.json"
+        if not force and existing_json.exists():
+            logger.info(
+                "Skipping row %d -> %s: dossier %s already exists",
+                idx,
+                pmcid,
+                existing_json.name,
+            )
+            continue
         logger.info("Processing row %d -> %s", idx, pmcid)
         try:
             csv_url = extract_pmc_url_from_row(row)
@@ -687,7 +697,11 @@ def main() -> None:
     parser.add_argument("--raw-dir", type=Path, default=Path("data/raw_pmc"), help="Directory for cached raw HTML")
     parser.add_argument("--json-dir", type=Path, default=Path("data/papers"), help="Directory for JSON dossiers")
     parser.add_argument("--limit", type=int, default=None, help="Optional row limit for testing")
-    parser.add_argument("--force", action="store_true", help="Refetch HTML even if cached")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Refetch HTML and overwrite dossiers even if cached",
+    )
     parser.add_argument("--llm", choices=["auto", "off"], default="auto", help="Use OpenAI if configured ('auto') or disable ('off')")
     parser.add_argument("--llm-model", default="gpt-4o-mini", help="OpenAI model name when LLM is enabled")
     parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase logging verbosity (use -vv for debug)")


### PR DESCRIPTION
## Summary
- skip rows whose JSON dossier already exists when rerunning the PMC ingestion pipeline
- allow --force to reprocess existing dossiers and update its CLI help text
- refresh developer notes to mention the expanded --force behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2bbe35bd883298defb7b4075f2fa2