### PR TITLE
Improve HUD divider readability

### DIFF
--- a/src/styles/hud-accents.css
+++ b/src/styles/hud-accents.css
@@ -273,11 +273,24 @@
 
 .hud-divider__label {
   font-family: var(--font-mono, 'Space Mono', monospace);
-  font-size: 0.6rem;
-  letter-spacing: 0.32em;
+  font-size: 0.72rem;
+  letter-spacing: 0.26em;
   text-transform: uppercase;
-  color: rgba(217, 226, 223, 0.86);
+  color: rgba(238, 246, 244, 0.94);
   white-space: nowrap;
+  padding: 0.38rem 1.15rem;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgba(8, 18, 26, 0) 0%,
+    rgba(8, 18, 26, 0.82) 18%,
+    rgba(8, 18, 26, 0.82) 82%,
+    rgba(8, 18, 26, 0) 100%
+  );
+  border: 1px solid rgba(115, 226, 255, 0.25);
+  box-shadow: 0 0 22px rgba(32, 198, 255, 0.18);
+  text-shadow: 0 0 12px rgba(32, 198, 255, 0.45);
+  backdrop-filter: blur(4px);
 }
 
 .hud-divider__label::before,
@@ -286,10 +299,11 @@
   display: inline-block;
   width: 6px;
   height: 6px;
-  border: 1px solid rgba(217, 226, 223, 0.48);
+  border: 1px solid rgba(188, 238, 255, 0.7);
   transform: rotate(45deg);
-  margin: 0 0.6rem;
-  opacity: 0.6;
+  margin: 0 0.75rem;
+  opacity: 0.75;
+  box-shadow: 0 0 8px rgba(32, 198, 255, 0.35);
 }
 
 .hud-divider__label--left::before {


### PR DESCRIPTION
## Summary
- brighten and enlarge the HUD divider label to improve legibility over the ticked header
- refresh the accompanying diamond markers to match the higher-contrast treatment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2bd0a167083298a9b2fd45293c1f2