### PR TITLE
Reduce corner rounding for primary surfaces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,10 +95,10 @@ const AppContent = () => {
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
               <Link
                 to="/"
-                className="group relative rounded-xl border border-[rgba(32,42,50,0.65)] bg-[rgba(13,20,26,0.95)] px-6 py-4 shadow-[0_12px_40px_rgba(0,0,0,0.6)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-2)]"
+                className="group relative rounded-[6px] border border-[rgba(32,42,50,0.65)] bg-[rgba(13,20,26,0.95)] px-6 py-4 shadow-[0_12px_40px_rgba(0,0,0,0.6)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-2)]"
                 aria-label="Return to AstroGenesis home"
               >
-                <div className="pointer-events-none absolute inset-0 rounded-xl bg-[radial-gradient(circle_at_top,_rgba(0,179,255,0.22),_transparent_68%)] transition-opacity group-hover:opacity-90" />
+                <div className="pointer-events-none absolute inset-0 rounded-[6px] bg-[radial-gradient(circle_at_top,_rgba(0,179,255,0.22),_transparent_68%)] transition-opacity group-hover:opacity-90" />
                 <div className="relative flex flex-col gap-1">
                   <span className="font-meta text-[0.7rem] tracking-[0.32em] text-[color:var(--accent-2)]/75 normal-case">Mission Control // A.G-01</span>
                   <span className="font-display text-[1.45rem] tracking-[0.32em] text-[var(--white)] transition-colors group-hover:text-[color:var(--accent-2)]">
@@ -160,7 +160,7 @@ const AppContent = () => {
             </Routes>
           </Suspense>
         </main>
-        <footer className="mx-6 mb-6 rounded-xl border border-[rgba(26,31,36,0.55)] bg-[rgba(9,14,18,0.85)] px-6 py-4 font-meta text-[0.72rem] tracking-[0.22em] text-[color:var(--passive)]">
+        <footer className="mx-6 mb-6 rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(9,14,18,0.85)] px-6 py-4 font-meta text-[0.72rem] tracking-[0.22em] text-[color:var(--passive)]">
           Signal integrity nominal // Press C for credentials · Press ? for help overlay
         </footer>
       </div>

--- a/src/components/ActiveFiltersBar.tsx
+++ b/src/components/ActiveFiltersBar.tsx
@@ -28,7 +28,7 @@ const ActiveFiltersBar = () => {
 
   if (entries.length === 0) {
     return (
-      <div className="flex items-center gap-4 rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.75)] px-5 py-3.5 font-meta text-[0.74rem] tracking-[0.22em] text-[color:var(--passive)] shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
+      <div className="flex items-center gap-4 rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.75)] px-5 py-3.5 font-meta text-[0.74rem] tracking-[0.22em] text-[color:var(--passive)] shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
         <span className="text-[rgba(85,230,165,0.8)]">Filters nominal</span>
         <span className="text-[color:var(--mid)]">// All dossiers shown</span>
       </div>
@@ -36,7 +36,7 @@ const ActiveFiltersBar = () => {
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-3 rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.75)] px-5 py-3.5 shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
+    <div className="flex flex-wrap items-center gap-3 rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.75)] px-5 py-3.5 shadow-[0_16px_38px_rgba(0,0,0,0.45)]">
       <span className="font-meta text-[0.74rem] tracking-[0.24em] text-[color:var(--accent-1)]">
         Active Filters
       </span>

--- a/src/components/CardStack.tsx
+++ b/src/components/CardStack.tsx
@@ -51,11 +51,11 @@ const StackCard = ({ item, index }: StackCardProps) => {
       onMouseLeave={handleLeave}
     >
       <div
-        className="absolute inset-0 -z-[1] rounded-2xl border border-[rgba(26,31,36,0.45)] bg-[rgba(12,18,24,0.72)] backdrop-blur-sm transition-transform duration-500 group-hover:-translate-y-2"
+        className="absolute inset-0 -z-[1] rounded-[6px] border border-[rgba(26,31,36,0.45)] bg-[rgba(12,18,24,0.72)] backdrop-blur-sm transition-transform duration-500 group-hover:-translate-y-2"
         style={{ transform: `translate3d(${tilt.x}px, ${tilt.y}px, 0)` }}
       />
       <article
-        className="scanline-card relative overflow-hidden rounded-2xl border border-[rgba(26,31,36,0.65)] bg-[rgba(10,15,20,0.88)] p-7 shadow-[0_28px_70px_rgba(0,0,0,0.5)] transition-transform duration-500 group-hover:-translate-y-3"
+        className="scanline-card relative overflow-hidden rounded-[6px] border border-[rgba(26,31,36,0.65)] bg-[rgba(10,15,20,0.88)] p-7 shadow-[0_28px_70px_rgba(0,0,0,0.5)] transition-transform duration-500 group-hover:-translate-y-3"
         style={{ transform: `translate3d(${tilt.x}px, ${tilt.y}px, 0)` }}
       >
         <header className="mb-6">
@@ -65,9 +65,9 @@ const StackCard = ({ item, index }: StackCardProps) => {
             offset={10}
             stroke={0.9}
             color="cyan"
-            className="stack-card-corner -m-4 rounded-lg p-4"
+            className="stack-card-corner -m-4 rounded-[4px] p-4"
           >
-            <FuiFrame grid="soft" tone="cyan" padding={14} className="relative z-[1] overflow-hidden rounded-lg">
+            <FuiFrame grid="soft" tone="cyan" padding={14} className="relative z-[1] overflow-hidden rounded-[4px]">
               <div className="space-y-4">
                 <div className="flex items-center justify-between font-meta text-[0.72rem] tracking-[0.24em] text-[color:var(--passive)] normal-case">
                   <span>Dossier {index.toString().padStart(3, '0')}</span>
@@ -86,17 +86,17 @@ const StackCard = ({ item, index }: StackCardProps) => {
         </header>
 
         <dl className="grid grid-cols-3 gap-3 text-[0.88rem] font-body text-[color:var(--mid)]">
-          <div className="rounded-xl border border-[rgba(26,31,36,0.55)] bg-[rgba(12,18,24,0.7)] px-4 py-3">
+          <div className="rounded-[5px] border border-[rgba(26,31,36,0.55)] bg-[rgba(12,18,24,0.7)] px-4 py-3">
             <dt className="text-[0.75rem] font-meta normal-case tracking-[0.12em] text-[color:var(--passive)]">Year</dt>
             <dd className="text-[color:var(--white)]">{item.year}</dd>
           </div>
-          <div className="rounded-xl border border-[rgba(26,31,36,0.55)] bg-[rgba(12,18,24,0.7)] px-4 py-3">
+          <div className="rounded-[5px] border border-[rgba(26,31,36,0.55)] bg-[rgba(12,18,24,0.7)] px-4 py-3">
             <dt className="text-[0.75rem] font-meta normal-case tracking-[0.12em] text-[color:var(--passive)]">Organism</dt>
             <dd className="truncate text-[color:var(--white)]" title={item.organism}>
               {item.organism}
             </dd>
           </div>
-          <div className="rounded-xl border border-[rgba(26,31,36,0.55)] bg-[rgba(12,18,24,0.7)] px-4 py-3">
+          <div className="rounded-[5px] border border-[rgba(26,31,36,0.55)] bg-[rgba(12,18,24,0.7)] px-4 py-3">
             <dt className="text-[0.75rem] font-meta normal-case tracking-[0.12em] text-[color:var(--passive)]">Platform</dt>
             <dd className="truncate text-[color:var(--white)]" title={item.platform}>
               {item.platform}
@@ -120,7 +120,7 @@ const StackCard = ({ item, index }: StackCardProps) => {
           <HudBadge label="Entities" tone="cyan" compact value={<span>{item.entities.length}</span>} />
         </div>
       </article>
-      <div className="pointer-events-none absolute inset-0 -z-[2] translate-x-2 translate-y-2 rounded-2xl border border-[rgba(26,31,36,0.45)] bg-[rgba(9,13,17,0.55)] opacity-70" />
+      <div className="pointer-events-none absolute inset-0 -z-[2] translate-x-2 translate-y-2 rounded-[6px] border border-[rgba(26,31,36,0.45)] bg-[rgba(9,13,17,0.55)] opacity-70" />
     </Link>
   );
 };
@@ -136,7 +136,7 @@ const Battery = ({ confidence }: BatteryProps) => {
     <div className="flex items-center gap-2">
       <span className="font-meta text-[0.72rem] tracking-[0.22em] text-[color:var(--passive)] normal-case">Confidence</span>
       <div className="flex items-center gap-2">
-        <div className="flex gap-1 rounded-lg border border-[rgba(26,31,36,0.55)] bg-[rgba(12,18,24,0.6)] px-1.5 py-1.5">
+        <div className="flex gap-1 rounded-[4px] border border-[rgba(26,31,36,0.55)] bg-[rgba(12,18,24,0.6)] px-1.5 py-1.5">
           {Array.from({ length: segments }).map((_, index) => (
             <span
               key={index}

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -23,7 +23,7 @@ const Filters = ({ organisms, platforms, years }: FilterProps) => {
 
   return (
     <aside className="flex h-full flex-col gap-6">
-      <header className="flex items-center justify-between rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.85)] px-4 py-3">
+      <header className="flex items-center justify-between rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.85)] px-4 py-3">
         <div>
           <p className="font-meta text-[0.74rem] tracking-[0.24em] text-[color:var(--accent-1)]">Filters</p>
           <h3 className="text-xl text-[color:var(--white)]">Operational scope</h3>
@@ -36,7 +36,7 @@ const Filters = ({ organisms, platforms, years }: FilterProps) => {
           Reset
         </button>
       </header>
-      <div className="space-y-6 rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-5">
+      <div className="space-y-6 rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-5">
         <FilterGroup
           label="Organism"
           options={organisms}

--- a/src/components/GridBg.tsx
+++ b/src/components/GridBg.tsx
@@ -81,7 +81,7 @@ const GridBg = () => {
         <rect width="100%" height="100%" fill="url(#diagonal)" />
       </svg>
 
-      <div className="absolute inset-6 rounded-3xl border border-[rgba(255,255,255,0.04)]" />
+      <div className="absolute inset-6 rounded-[8px] border border-[rgba(255,255,255,0.04)]" />
       <CornerTick position="top-left" />
       <CornerTick position="top-right" />
       <CornerTick position="bottom-left" />
@@ -97,10 +97,10 @@ type CornerTickProps = {
 const CornerTick = ({ position }: CornerTickProps) => {
   const common = 'absolute h-10 w-10 border border-[rgba(255,255,255,0.08)]';
   const map: Record<CornerTickProps['position'], string> = {
-    'top-left': 'left-6 top-6 border-r-0 border-b-0 rounded-tl-xl',
-    'top-right': 'right-6 top-6 border-l-0 border-b-0 rounded-tr-xl',
-    'bottom-left': 'left-6 bottom-6 border-r-0 border-t-0 rounded-bl-xl',
-    'bottom-right': 'right-6 bottom-6 border-l-0 border-t-0 rounded-br-xl'
+    'top-left': 'left-6 top-6 border-r-0 border-b-0 rounded-tl-[6px]',
+    'top-right': 'right-6 top-6 border-l-0 border-b-0 rounded-tr-[6px]',
+    'bottom-left': 'left-6 bottom-6 border-r-0 border-t-0 rounded-bl-[6px]',
+    'bottom-right': 'right-6 bottom-6 border-l-0 border-t-0 rounded-br-[6px]'
   };
   return <span className={`${common} ${map[position]}`} />;
 };

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -143,7 +143,7 @@ const Home = () => {
         <span className="section-anchor">Mission Control</span>
         <div className="layered-panel grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
           <div className="space-y-6">
-            <div className="relative overflow-hidden rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-6 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+            <div className="relative overflow-hidden rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-6 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
               <ReticleOverlay
                 mode="fine"
                 animated
@@ -184,7 +184,7 @@ const Home = () => {
               </div>
             </div>
 
-            <div className="rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-6">
+            <div className="rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-6">
               <SignalUplinkIndicator
                 active={uplinkActive}
                 restored={connectionRestored}
@@ -212,7 +212,7 @@ const Home = () => {
               </div>
             </div>
           </div>
-          <div className="rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-6 shadow-[0_18px_48px_rgba(0,0,0,0.4)]">
+          <div className="rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-6 shadow-[0_18px_48px_rgba(0,0,0,0.4)]">
             <Filters {...filterOptions} />
           </div>
         </div>
@@ -271,7 +271,7 @@ type MissionTimelineProps = {
 const MissionTimeline = ({ timeline, activeYear, onYearChange }: MissionTimelineProps) => {
   if (timeline.length === 0) {
     return (
-      <div className="rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.75)] p-6 text-[color:var(--mid)]">
+      <div className="rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.75)] p-6 text-[color:var(--mid)]">
         No mission chronology detected. Adjust filters to rehydrate the transmission.
       </div>
     );
@@ -281,7 +281,7 @@ const MissionTimeline = ({ timeline, activeYear, onYearChange }: MissionTimeline
   const maxYear = timeline[0]?.year ?? 0;
 
   return (
-    <div className="rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-6">
+    <div className="rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-6">
       <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="font-meta text-[0.74rem] tracking-[0.22em] text-[color:var(--accent-1)]">Mission Timeline</p>
@@ -294,7 +294,7 @@ const MissionTimeline = ({ timeline, activeYear, onYearChange }: MissionTimeline
         </div>
       </header>
       <div className="mt-6 space-y-6">
-        <div className="relative h-32 overflow-hidden rounded-xl border border-[rgba(26,31,36,0.55)] bg-[rgba(9,14,18,0.75)] p-6">
+        <div className="relative h-32 overflow-hidden rounded-[5px] border border-[rgba(26,31,36,0.55)] bg-[rgba(9,14,18,0.75)] p-6">
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(0,179,255,0.15),_transparent_65%)] opacity-60" />
           <div className="relative flex h-full items-center justify-between">
             {timeline.map((point) => (
@@ -356,7 +356,7 @@ type TimelineTooltipProps = {
 
 const TimelineTooltip = ({ point, active }: TimelineTooltipProps) => (
   <div
-    className={`pointer-events-none absolute -top-28 flex w-56 flex-col gap-2 rounded-xl border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.9)] p-4 text-left shadow-[0_18px_48px_rgba(0,0,0,0.45)] transition-all duration-300 ${
+    className={`pointer-events-none absolute -top-28 flex w-56 flex-col gap-2 rounded-[5px] border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.9)] p-4 text-left shadow-[0_18px_48px_rgba(0,0,0,0.45)] transition-all duration-300 ${
       active ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-3'
     }`}
   >
@@ -388,7 +388,7 @@ const ConfidenceHeatGrid = ({ matrix, activeYear, onYearChange }: ConfidenceHeat
   }
 
   return (
-    <div className="rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-6">
+    <div className="rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.8)] p-6">
       <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="font-meta text-[0.74rem] tracking-[0.22em] text-[color:var(--accent-1)]">Confidence Heat Grid</p>
@@ -427,7 +427,7 @@ const ConfidenceHeatGrid = ({ matrix, activeYear, onYearChange }: ConfidenceHeat
                 {matrix.values[rowIndex]?.map((value, columnIndex) => (
                   <td key={`${organism}-${matrix.years[columnIndex]}`}>
                     <div
-                      className={`group relative flex h-14 items-center justify-center rounded-lg border border-[rgba(26,31,36,0.45)] bg-[rgba(12,18,24,0.65)] transition ${
+                      className={`group relative flex h-14 items-center justify-center rounded-[4px] border border-[rgba(26,31,36,0.45)] bg-[rgba(12,18,24,0.65)] transition ${
                         activeYear === matrix.years[columnIndex]
                           ? 'ring-1 ring-[rgba(0,179,255,0.45)] ring-offset-2 ring-offset-[rgba(8,12,16,0.85)]'
                           : ''
@@ -472,7 +472,7 @@ type HeatTooltipProps = {
 
 const HeatTooltip = ({ organism, year, value, active }: HeatTooltipProps) => (
   <div
-    className={`pointer-events-none absolute -top-32 flex w-48 flex-col gap-2 rounded-xl border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.94)] p-4 text-left transition-all duration-300 ${
+    className={`pointer-events-none absolute -top-32 flex w-48 flex-col gap-2 rounded-[5px] border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.94)] p-4 text-left transition-all duration-300 ${
       active ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
     }`}
   >
@@ -498,7 +498,7 @@ const HabitableMapVisualizer = ({ records, activeYear }: HabitableMapVisualizerP
   const nodes = buildHabitableNodes(records, activeYear);
 
   return (
-    <div className="rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.82)] p-6">
+    <div className="rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.82)] p-6">
       <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="font-meta text-[0.74rem] tracking-[0.22em] text-[color:var(--accent-2)]">Habitable Map Visualizer</p>
@@ -506,7 +506,7 @@ const HabitableMapVisualizer = ({ records, activeYear }: HabitableMapVisualizerP
         </div>
         <span className="font-meta text-[0.7rem] tracking-[0.22em] text-[color:var(--mid)]">Interconnected organisms · platforms · years</span>
       </header>
-      <div className="relative mt-6 overflow-hidden rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.75)] p-6">
+      <div className="relative mt-6 overflow-hidden rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.75)] p-6">
         <svg viewBox="0 0 640 320" className="h-72 w-full">
           <defs>
             <linearGradient id="node-gradient" x1="0" x2="1" y1="0" y2="1">
@@ -567,7 +567,7 @@ type AnalystSummaryProps = {
 
 const AnalystSummary = ({ summaries }: AnalystSummaryProps) => (
   <div className="flex h-full flex-col gap-6">
-    <div className="rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.82)] p-6">
+    <div className="rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(10,15,20,0.82)] p-6">
       <p className="font-meta text-[0.74rem] tracking-[0.22em] text-[color:var(--accent-2)]">Analyst Summary</p>
       <h3 className="mt-2 text-2xl text-[color:var(--white)]">LLM brief of prioritized dossiers</h3>
       <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-[color:var(--mid)]">
@@ -578,7 +578,7 @@ const AnalystSummary = ({ summaries }: AnalystSummaryProps) => (
       {summaries.map((item, index) => (
         <article
           key={item.id}
-          className="group relative overflow-hidden rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.9)] p-5 shadow-[0_18px_48px_rgba(0,0,0,0.4)] transition hover:shadow-[0_20px_60px_rgba(0,179,255,0.25)]"
+          className="group relative overflow-hidden rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.9)] p-5 shadow-[0_18px_48px_rgba(0,0,0,0.4)] transition hover:shadow-[0_20px_60px_rgba(0,179,255,0.25)]"
         >
           <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" style={{ backgroundImage: 'linear-gradient(135deg, rgba(0,179,255,0.12), rgba(85,230,165,0.1))' }} />
           <div className="relative flex flex-col gap-3">
@@ -615,7 +615,7 @@ const TransmissionIntegrityMeter = ({ integrity, totalRecords, activeYear }: Tra
   const offset = circumference * (1 - normalized);
 
   return (
-    <div className="relative flex flex-col items-center justify-center rounded-2xl border border-[rgba(26,31,36,0.55)] bg-[rgba(9,14,18,0.8)] p-6 text-center">
+    <div className="relative flex flex-col items-center justify-center rounded-[6px] border border-[rgba(26,31,36,0.55)] bg-[rgba(9,14,18,0.8)] p-6 text-center">
       <p className="font-meta text-[0.74rem] tracking-[0.22em] text-[color:var(--accent-2)]">Transmission Integrity</p>
       <div className="relative mt-4 h-40 w-40">
         <svg viewBox="0 0 140 140" className="h-full w-full">
@@ -660,7 +660,7 @@ type SignalUplinkIndicatorProps = {
 };
 
 const SignalUplinkIndicator = ({ active, restored, hasError }: SignalUplinkIndicatorProps) => (
-  <div className="flex items-center justify-between rounded-xl border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.85)] px-4 py-3">
+  <div className="flex items-center justify-between rounded-[5px] border border-[rgba(26,31,36,0.55)] bg-[rgba(8,12,16,0.85)] px-4 py-3">
     <div className="flex items-center gap-3 font-meta text-[0.72rem] tracking-[0.24em] text-[color:var(--mid)]">
       <span
         className={`inline-flex h-3 w-3 rounded-full shadow-[0_0_16px_rgba(0,179,255,0.6)] ${
@@ -684,7 +684,7 @@ type EmptyStateProps = {
 };
 
 const EmptyState = ({ restoring }: EmptyStateProps) => (
-  <div className="relative flex h-64 flex-col items-center justify-center overflow-hidden rounded-2xl border border-dashed border-[rgba(0,179,255,0.25)] bg-[rgba(9,12,15,0.7)] text-center">
+  <div className="relative flex h-64 flex-col items-center justify-center overflow-hidden rounded-[6px] border border-dashed border-[rgba(0,179,255,0.25)] bg-[rgba(9,12,15,0.7)] text-center">
     <div className="absolute inset-0 animate-[signalLost_3s_ease-in-out_infinite] bg-[radial-gradient(circle_at_center,_rgba(0,179,255,0.12),_transparent_65%)]" />
     <div className="relative flex flex-col items-center gap-3">
       <p className="font-meta text-[0.86rem] tracking-[0.24em] text-[color:var(--mid)]">Signal lost</p>

--- a/src/routes/Paper.tsx
+++ b/src/routes/Paper.tsx
@@ -132,7 +132,7 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
 
   return (
     <div className="space-y-8 transmission-field">
-      <header className="relative overflow-hidden rounded-[12px] border border-[#d6e3e0]/16 bg-[rgba(12,18,24,0.86)] p-6 shadow-[0_30px_70px_rgba(0,0,0,0.42)]">
+      <header className="relative overflow-hidden rounded-[6px] border border-[#d6e3e0]/16 bg-[rgba(12,18,24,0.86)] p-6 shadow-[0_30px_70px_rgba(0,0,0,0.42)]">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(0,179,255,0.18),transparent_55%)] opacity-70 mix-blend-screen" aria-hidden="true" />
         <div className="flex flex-wrap items-start justify-between gap-6">
           <div className="space-y-3">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -180,7 +180,7 @@ a:focus-visible {
 
   .layered-panel {
     position: relative;
-    border-radius: 12px;
+    border-radius: 6px;
     border: 1px solid rgba(28, 36, 44, 0.75);
     background: var(--panel);
     backdrop-filter: blur(18px);
@@ -213,7 +213,7 @@ a:focus-visible {
     align-items: center;
     gap: 12px;
     padding: 0.4rem 0.85rem;
-    border-radius: 6px;
+    border-radius: 4px;
     border: 1px solid rgba(0, 179, 255, 0.5);
     background:
       linear-gradient(180deg, rgba(4, 20, 28, 0.95), rgba(4, 20, 28, 0.6))
@@ -239,7 +239,7 @@ a:focus-visible {
   .branch-map-shell {
     position: relative;
     overflow: hidden;
-    border-radius: 14px;
+    border-radius: 8px;
     border: 1px solid rgba(0, 179, 255, 0.2);
     background: linear-gradient(180deg, rgba(8, 12, 16, 0.92), rgba(8, 12, 16, 0.76));
     box-shadow: 0 28px 60px rgba(0, 0, 0, 0.45);
@@ -322,7 +322,7 @@ a:focus-visible {
   .dossier-meta {
     position: relative;
     overflow: hidden;
-    border-radius: 16px;
+    border-radius: 8px;
     border: 1px solid rgba(85, 230, 165, 0.3);
     background: linear-gradient(180deg, rgba(9, 14, 20, 0.85), rgba(9, 14, 20, 0.6));
     padding: 24px;
@@ -456,7 +456,7 @@ a:focus-visible {
 
   .meta-entities li {
     padding: 0.6rem 0.9rem;
-    border-radius: 10px;
+    border-radius: 5px;
     border: 1px solid rgba(214, 227, 224, 0.18);
     background: rgba(11, 16, 22, 0.6);
     box-shadow: inset 0 0 12px rgba(0, 179, 255, 0.12);
@@ -1230,7 +1230,7 @@ a:focus-visible {
   position: relative;
   width: min(90vw, 560px);
   padding: clamp(32px, 6vw, 48px) clamp(36px, 6vw, 56px);
-  border-radius: 24px;
+  border-radius: 12px;
   border: 1px solid rgba(0, 179, 255, 0.28);
   background: linear-gradient(135deg, rgba(14, 20, 26, 0.94), rgba(8, 12, 16, 0.92));
   box-shadow: 0 30px 90px rgba(0, 0, 0, 0.75), 0 0 0 1px rgba(12, 24, 32, 0.6);
@@ -1242,7 +1242,7 @@ a:focus-visible {
   content: '';
   position: absolute;
   inset: 12px;
-  border-radius: 16px;
+  border-radius: 8px;
   border: 1px solid rgba(85, 230, 165, 0.18);
   opacity: 0.5;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- reduce border radii across primary layout panels, cards, and controls for a sharper console aesthetic
- update shared styles so layered panels, branch map shells, and modal panes inherit the new lower-radius treatment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2bb9412708329bcdb90656fbf2b89