### PR TITLE
Reduce rounded corners for sharper panels

### DIFF
--- a/src/routes/Paper.tsx
+++ b/src/routes/Paper.tsx
@@ -132,7 +132,7 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
 
   return (
     <div className="space-y-8 transmission-field">
-      <header className="relative overflow-hidden rounded-[12px] border border-[#d6e3e0]/16 bg-[rgba(12,18,24,0.86)] p-6 shadow-[0_30px_70px_rgba(0,0,0,0.42)]">
+      <header className="relative overflow-hidden rounded-[8px] border border-[#d6e3e0]/16 bg-[rgba(12,18,24,0.86)] p-6 shadow-[0_30px_70px_rgba(0,0,0,0.42)]">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(0,179,255,0.18),transparent_55%)] opacity-70 mix-blend-screen" aria-hidden="true" />
         <div className="flex flex-wrap items-start justify-between gap-6">
           <div className="space-y-3">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -186,7 +186,7 @@ a:focus-visible {
 
   .layered-panel {
     position: relative;
-    border-radius: 12px;
+    border-radius: 8px;
     border: 1px solid rgba(28, 36, 44, 0.75);
     background: var(--panel);
     backdrop-filter: blur(18px);
@@ -219,7 +219,7 @@ a:focus-visible {
     align-items: center;
     gap: 12px;
     padding: 0.4rem 0.85rem;
-    border-radius: 6px;
+    border-radius: 4px;
     border: 1px solid rgba(0, 179, 255, 0.5);
     background:
       linear-gradient(180deg, rgba(4, 20, 28, 0.95), rgba(4, 20, 28, 0.6))
@@ -245,7 +245,7 @@ a:focus-visible {
   .branch-map-shell {
     position: relative;
     overflow: hidden;
-    border-radius: 14px;
+    border-radius: 10px;
     border: 1px solid rgba(0, 179, 255, 0.2);
     background: linear-gradient(180deg, rgba(8, 12, 16, 0.92), rgba(8, 12, 16, 0.76));
     box-shadow: 0 28px 60px rgba(0, 0, 0, 0.45);
@@ -328,7 +328,7 @@ a:focus-visible {
   .dossier-meta {
     position: relative;
     overflow: hidden;
-    border-radius: 16px;
+    border-radius: 10px;
     border: 1px solid rgba(85, 230, 165, 0.3);
     background: linear-gradient(180deg, rgba(9, 14, 20, 0.85), rgba(9, 14, 20, 0.6));
     padding: 24px;
@@ -462,7 +462,7 @@ a:focus-visible {
 
   .meta-entities li {
     padding: 0.6rem 0.9rem;
-    border-radius: 10px;
+    border-radius: 6px;
     border: 1px solid rgba(214, 227, 224, 0.18);
     background: rgba(11, 16, 22, 0.6);
     box-shadow: inset 0 0 12px rgba(0, 179, 255, 0.12);
@@ -1001,7 +1001,7 @@ a:focus-visible {
 .splash-wrap .splash-grid {
   inset: clamp(72px, 12vw, 180px);
   border: 1px solid rgba(0, 179, 255, 0.28);
-  border-radius: clamp(22px, 4vw, 36px);
+  border-radius: clamp(16px, 3vw, 28px);
   background-image: linear-gradient(rgba(0, 179, 255, 0.18) 1px, transparent 1px),
     linear-gradient(90deg, rgba(85, 230, 165, 0.18) 1px, transparent 1px);
   background-size: 44px 44px;
@@ -1236,7 +1236,7 @@ a:focus-visible {
   position: relative;
   width: min(90vw, 560px);
   padding: clamp(32px, 6vw, 48px) clamp(36px, 6vw, 56px);
-  border-radius: 24px;
+  border-radius: 12px;
   border: 1px solid rgba(0, 179, 255, 0.28);
   background: linear-gradient(135deg, rgba(14, 20, 26, 0.94), rgba(8, 12, 16, 0.92));
   box-shadow: 0 30px 90px rgba(0, 0, 0, 0.75), 0 0 0 1px rgba(12, 24, 32, 0.6);
@@ -1248,7 +1248,7 @@ a:focus-visible {
   content: '';
   position: absolute;
   inset: 12px;
-  border-radius: 16px;
+  border-radius: 8px;
   border: 1px solid rgba(85, 230, 165, 0.18);
   opacity: 0.5;
   pointer-events: none;

--- a/src/styles/splash.css
+++ b/src/styles/splash.css
@@ -50,7 +50,7 @@
   position: absolute;
   inset: clamp(0.25rem, 1vw, 0.6rem);
   border: 1px solid rgba(85, 230, 165, 0.18);
-  border-radius: 14px;
+  border-radius: 10px;
   pointer-events: none;
   opacity: 0.6;
   mix-blend-mode: screen;
@@ -132,7 +132,7 @@
   position: relative;
   z-index: 2;
   background: linear-gradient(135deg, rgba(18, 27, 32, 0.9), rgba(12, 18, 22, 0.78));
-  border-radius: 14px;
+  border-radius: 10px;
   border: 1px solid rgba(68, 101, 110, 0.7);
   box-shadow: 0 40px 120px rgba(0, 0, 0, 0.38), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
   padding: clamp(2rem, 5vw, 3.2rem);
@@ -144,7 +144,7 @@
 .credential-pane__frame {
   position: absolute;
   inset: 0.5rem;
-  border-radius: 10px;
+  border-radius: 6px;
   border: 1px solid rgba(85, 230, 165, 0.12);
   pointer-events: none;
   background:
@@ -315,7 +315,7 @@
   display: flex;
   align-items: center;
   padding: 0.65rem 1rem;
-  border-radius: 8px;
+  border-radius: 4px;
   border: 1px solid rgba(60, 78, 84, 0.8);
   background: linear-gradient(90deg, rgba(10, 18, 24, 0.85), rgba(16, 24, 28, 0.65));
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -21,6 +21,13 @@ module.exports = {
         dim: 'var(--dim)'
       },
       borderRadius: {
+        DEFAULT: '4px',
+        sm: '2px',
+        md: '5px',
+        lg: '6px',
+        xl: '8px',
+        '2xl': '10px',
+        '3xl': '14px',
         hud: '18px'
       },
       boxShadow: {


### PR DESCRIPTION
## Summary
- dial back the border radius on core panels and shells for a crisper aesthetic
- tighten the Tailwind border radius scale so rounded utility classes default to smaller curves
- align the dossier header splash with the new corner treatment

## Testing
- npm run build *(fails: TS2552 because HudDivider component is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c49e31e88329a55e439bc156e1d6