### PR TITLE
Restore HUD divider styling for dossier headers

### DIFF
--- a/src/components/fui/HudDivider.tsx
+++ b/src/components/fui/HudDivider.tsx
@@ -1,32 +1,292 @@
 import clsx from 'clsx';
-import TickRuler from './TickRuler';
+import {
+  type CSSProperties,
+  type HTMLAttributes,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+
+import '@/styles/fui.css';
 import '@/styles/hud-accents.css';
 
-type HudDividerProps = {
-  label: string;
+const ACCENT_MAP = {
+  cyan: {
+    tone: 'var(--hud-cyan)',
+    glow: 'rgba(85, 230, 165, 0.55)'
+  },
+  amber: {
+    tone: 'var(--hud-amber)',
+    glow: 'rgba(255, 176, 32, 0.55)'
+  },
+  red: {
+    tone: 'var(--hud-red)',
+    glow: 'rgba(255, 77, 79, 0.55)'
+  },
+  mono: {
+    tone: 'var(--hud-dim)',
+    glow: 'rgba(145, 163, 158, 0.48)'
+  }
+} as const;
+
+const DEFAULT_SPACING = 12;
+const DEFAULT_MAJOR_EVERY = 5;
+
+type LegacyDividerProps = {
   side?: 'left' | 'right' | 'center';
   compact?: boolean;
-  className?: string;
 };
 
-const HudDivider = ({ label, side = 'left', compact = false, className }: HudDividerProps) => {
-  const labelClass = clsx('hud-divider__label', {
-    'hud-divider__label--left': side === 'left',
-    'hud-divider__label--right': side === 'right',
-    'hud-divider__label--center': side === 'center'
-  });
+export type RulerHeadingProps = {
+  label: string;
+  align?: 'start' | 'center' | 'end';
+  accent?: 'cyan' | 'amber' | 'red' | 'mono';
+  variant?: 'knockout' | 'pill' | 'underbar';
+  ticks?: {
+    spacing?: number;
+    majorEvery?: number;
+  };
+  lanePadding?: number;
+  elevate?: boolean;
+  ariaLabel?: string;
+} & LegacyDividerProps &
+  Omit<HTMLAttributes<HTMLDivElement>, 'aria-label'>;
+
+type LayoutSnapshot = {
+  containerWidth: number;
+  labelWidth: number;
+  labelLeft: number;
+};
+
+const initialLayout: LayoutSnapshot = {
+  containerWidth: 0,
+  labelWidth: 0,
+  labelLeft: 0
+};
+
+const resolveAlign = (align?: RulerHeadingProps['align'], side?: LegacyDividerProps['side']) => {
+  if (align) {
+    return align;
+  }
+
+  switch (side) {
+    case 'left':
+      return 'start';
+    case 'right':
+      return 'end';
+    default:
+      return 'center';
+  }
+};
+
+const HudDivider = ({
+  label,
+  align,
+  accent = 'cyan',
+  variant = 'knockout',
+  ticks,
+  lanePadding = 14,
+  elevate = false,
+  ariaLabel,
+  className,
+  side,
+  compact,
+  role,
+  tabIndex,
+  ...rest
+}: RulerHeadingProps) => {
+  const resolvedAlign = resolveAlign(align, side);
+  const accentInfo = ACCENT_MAP[accent] ?? ACCENT_MAP.cyan;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const maskId = useId();
+
+  const [{ containerWidth, labelWidth, labelLeft }, setLayout] = useState<LayoutSnapshot>(initialLayout);
+
+  useEffect(() => {
+    if (!containerRef.current || !labelRef.current || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const containerNode = containerRef.current;
+    const labelNode = labelRef.current;
+
+    const updateLayout = () => {
+      if (!containerNode || !labelNode) {
+        return;
+      }
+
+      const containerRect = containerNode.getBoundingClientRect();
+      const labelRect = labelNode.getBoundingClientRect();
+
+      setLayout((prev) => {
+        const next = {
+          containerWidth: containerRect.width,
+          labelWidth: labelRect.width,
+          labelLeft: labelRect.left - containerRect.left
+        } satisfies LayoutSnapshot;
+
+        if (
+          prev.containerWidth === next.containerWidth &&
+          prev.labelWidth === next.labelWidth &&
+          prev.labelLeft === next.labelLeft
+        ) {
+          return prev;
+        }
+
+        return next;
+      });
+    };
+
+    updateLayout();
+
+    const resizeObserver = new ResizeObserver(updateLayout);
+    resizeObserver.observe(containerNode);
+    resizeObserver.observe(labelNode);
+
+    const mutationObserver = new MutationObserver(updateLayout);
+    mutationObserver.observe(labelNode, { subtree: true, childList: true, characterData: true });
+
+    window.addEventListener('resize', updateLayout);
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+      window.removeEventListener('resize', updateLayout);
+    };
+  }, [label, lanePadding, resolvedAlign, variant]);
+
+  const tickSpacing = Math.max(4, ticks?.spacing ?? DEFAULT_SPACING);
+  const majorEvery = Math.max(1, ticks?.majorEvery ?? DEFAULT_MAJOR_EVERY);
+
+  const laneWidth = Math.max(0, labelWidth + lanePadding * 2);
+  const laneStart = Math.max(0, Math.min(labelLeft - lanePadding, Math.max(containerWidth - laneWidth, 0)));
+  const maskedLaneWidth = Math.max(0, Math.min(laneWidth, Math.max(containerWidth - laneStart, 0)));
+
+  const viewWidth = Math.max(containerWidth || 0, 1);
+  const viewHeight = 28;
+
+  const ticksMarkup = useMemo(() => {
+    if (!containerWidth) {
+      return null;
+    }
+
+    const segments = Math.ceil(containerWidth / tickSpacing) + 2;
+    const lines = [] as JSX.Element[];
+
+    for (let index = 0; index < segments; index += 1) {
+      const x = index * tickSpacing;
+      const length = index % majorEvery === 0 ? 12 : 6;
+      const y1 = viewHeight / 2 - length;
+      const y2 = viewHeight / 2 + length;
+
+      lines.push(
+        <line
+          key={`tick-${index}`}
+          x1={x}
+          y1={y1}
+          x2={x}
+          y2={y2}
+          className={clsx('fui-ruler__tick', {
+            'fui-ruler__tick--major': index % majorEvery === 0
+          })}
+        />
+      );
+    }
+
+    return lines;
+  }, [containerWidth, majorEvery, tickSpacing]);
+
+  const maskRectHeight = variant === 'underbar' ? 10 : viewHeight;
+  const maskRectY = variant === 'underbar' ? viewHeight - maskRectHeight : 0;
+
+  const ariaLabelText = ariaLabel ?? label;
+  const computedTabIndex = tabIndex ?? (role === 'heading' ? 0 : undefined);
+
+  const styleVariables: CSSProperties = {
+    '--fui-accent': accentInfo.tone,
+    '--fui-accent-glow': accentInfo.glow
+  } as CSSProperties;
 
   return (
-    <div className={clsx('hud-divider', compact && 'hud-divider--compact', className)}>
-      {side === 'right' || side === 'center' ? (
-        <TickRuler orientation="horizontal" className="hud-divider__ticks" spacing={12} majorEvery={5} align="start" />
+    <div
+      ref={containerRef}
+      className={clsx(
+        'fui-ruler',
+        compact && 'fui-ruler--compact',
+        elevate && 'fui-ruler--elevated',
+        `fui-ruler--${resolvedAlign}`,
+        `fui-ruler--${variant}`,
+        className
+      )}
+      data-accent={accent}
+      data-variant={variant}
+      role={role}
+      tabIndex={computedTabIndex}
+      aria-label={ariaLabelText}
+      style={styleVariables}
+      {...rest}
+    >
+      <svg
+        className="fui-ruler__svg"
+        width="100%"
+        height={compact ? 24 : viewHeight}
+        viewBox={`0 0 ${viewWidth} ${viewHeight}`}
+        preserveAspectRatio="none"
+      >
+        {variant !== 'pill' && maskedLaneWidth > 0 ? (
+          <defs>
+            <mask id={maskId}>
+              <rect x={0} y={0} width="100%" height="100%" fill="white" />
+              <rect x={laneStart} y={maskRectY} width={maskedLaneWidth} height={maskRectHeight} fill="black" />
+            </mask>
+          </defs>
+        ) : null}
+
+        <g className="fui-ruler__ticks" mask={variant !== 'pill' && maskedLaneWidth > 0 ? `url(#${maskId})` : undefined}>
+          <line x1={0} y1={viewHeight / 2} x2={viewWidth} y2={viewHeight / 2} className="fui-ruler__baseline" />
+          {ticksMarkup}
+        </g>
+
+        {variant === 'underbar' && maskedLaneWidth > 0 ? (
+          <rect
+            x={laneStart}
+            y={viewHeight - 4}
+            width={maskedLaneWidth}
+            height={2}
+            rx={1}
+            className="fui-ruler__underbar"
+          />
+        ) : null}
+      </svg>
+
+      {variant === 'pill' && maskedLaneWidth > 0 ? (
+        <div
+          className={clsx('fui-pill', elevate && 'fui-pill--elevated')}
+          data-accent={accent}
+          style={{ left: `${laneStart}px`, width: `${maskedLaneWidth}px` }}
+          aria-hidden="true"
+        />
       ) : null}
-      <span className={labelClass}>{label}</span>
-      {side === 'left' || side === 'center' ? (
-        <TickRuler orientation="horizontal" className="hud-divider__ticks" spacing={12} majorEvery={5} align="end" />
-      ) : null}
+
+      <div
+        className={clsx('fui-ruler__label-layer', `fui-ruler__label-layer--${resolvedAlign}`)}
+        style={{ '--lane-padding': `${lanePadding}px` } as CSSProperties}
+        aria-hidden="true"
+      >
+        <span
+          ref={labelRef}
+          className={clsx('fui-ruler__label', elevate && 'fui-ruler__label--elevated')}
+          data-accent={accent}
+        >
+          {label}
+        </span>
+      </div>
     </div>
   );
 };
 
 export default HudDivider;
+

--- a/src/components/fui/index.ts
+++ b/src/components/fui/index.ts
@@ -4,5 +4,6 @@ export { default as FuiCallout } from './FuiCallout';
 export { default as FuiBadge } from './FuiBadge';
 export { default as FuiFrame } from './FuiFrame';
 export { default as FuiDivider } from './FuiDivider';
+export { default as HudDivider } from './HudDivider';
 export { FuiConnectorLayer, useConnectorLayer } from './useConnectorLayer';
 export type { AnchorSide } from './useConnectorLayer';

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -14,7 +14,7 @@ import ActiveFiltersBar from '../components/ActiveFiltersBar';
 import { useSearchStore } from '../lib/state';
 import { buildIndex, runSearch, getCachedRecords } from '../lib/search';
 import { withBase } from '../lib/paths';
-import { FuiBadge, FuiCallout, FuiConnectorLayer, FuiDivider } from '@/components/fui';
+import { FuiBadge, FuiCallout, FuiConnectorLayer, HudDivider } from '@/components/fui';
 
 const fetchIndex = async (): Promise<PaperIndex[]> => {
   const response = await fetch(withBase('data/index.json'));
@@ -244,7 +244,7 @@ const Home = () => {
       <section className="relative">
         <span className="section-anchor">Dossier Grid</span>
         <div className="layered-panel space-y-6 px-6 py-6">
-          <FuiDivider label="RESULTS" tone="cyan" />
+          <HudDivider label="RESULTS" accent="cyan" variant="pill" lanePadding={16} elevate />
           <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="font-meta text-[0.78rem] tracking-[0.22em] text-[color:var(--accent-2)]">Results</p>

--- a/src/routes/Paper.tsx
+++ b/src/routes/Paper.tsx
@@ -9,7 +9,7 @@ import HudBadge from '@/components/fui/HudBadge';
 import ReticleOverlay from '@/components/fui/ReticleOverlay';
 import CornerBracket from '@/components/fui/CornerBracket';
 import VectorGlyph from '@/components/fui/VectorGlyph';
-import { FuiBadge, FuiCallout, FuiConnectorLayer, FuiCorner, FuiDivider, useConnectorLayer } from '@/components/fui';
+import { FuiBadge, FuiCallout, FuiConnectorLayer, HudDivider, useConnectorLayer } from '@/components/fui';
 import DossierGlyphs from '../components/DossierGlyphs';
 import { getPaperFromCache, upsertPaperDetail } from '../lib/db';
 import type { PaperDetail } from '../lib/types';
@@ -165,19 +165,19 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
       <div className="grid gap-8 lg:grid-cols-[1.65fr_1fr]">
         <div className="space-y-6">
           <CornerBracket radius={10} size={24} offset={12} color="cyan" glow>
-            <div className="relative">
-              <FuiCorner tone="cyan" inset={8} className="pointer-events-none" />
-              <ReticleOverlay
-                mode="fine"
-                animated={false}
-                padding={18}
-                color="cyan"
-                showCompass
-                className="absolute inset-0 opacity-60"
-              >
-                <span className="text-[0.55rem] tracking-[0.28em] text-[rgba(85,230,165,0.8)]">BRANCH MAP</span>
-              </ReticleOverlay>
-              <BranchMap title={title} activeSection={activeSection} onSectionChange={(key) => onSectionChange(key)} />
+            <div className="relative flex flex-col gap-4">
+              <HudDivider label="BRANCH MAP" accent="cyan" variant="pill" lanePadding={16} elevate />
+              <div className="relative">
+                <ReticleOverlay
+                  mode="fine"
+                  animated={false}
+                  padding={18}
+                  color="cyan"
+                  showCompass
+                  className="pointer-events-none absolute inset-0"
+                />
+                <BranchMap title={title} activeSection={activeSection} onSectionChange={(key) => onSectionChange(key)} />
+              </div>
             </div>
           </CornerBracket>
 
@@ -341,7 +341,7 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
           </div>
 
           <DossierGlyphs />
-          <FuiDivider label="TELEMETRY" side="right" tone="amber" />
+          <HudDivider label="TELEMETRY" accent="amber" side="right" lanePadding={16} elevate />
           <TrendMini data={citations_by_year} />
         </aside>
       </div>

--- a/src/styles/fui.css
+++ b/src/styles/fui.css
@@ -6,6 +6,11 @@
   --fui-cyan: #55e6a5;
   --fui-amber: #ffb020;
   --fui-red: #ff4d4f;
+  --hud-white: #e8f2ef;
+  --hud-dim: #91a39e;
+  --hud-cyan: #55e6a5;
+  --hud-amber: #ffb020;
+  --hud-red: #ff4d4f;
 }
 
 .fui-tone-mono { --fui-tone: var(--fui-mono); }
@@ -174,6 +179,146 @@
   z-index: 1;
 }
 
+.fui-ruler {
+  position: relative;
+  height: 28px;
+  display: block;
+  color: var(--hud-white);
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+}
+
+.fui-ruler--compact {
+  height: 24px;
+}
+
+.fui-ruler__svg {
+  width: 100%;
+  height: 28px;
+  display: block;
+}
+
+.fui-ruler--compact .fui-ruler__svg {
+  height: 24px;
+}
+
+.fui-ruler__ticks {
+  stroke: var(--fui-accent, var(--hud-cyan));
+  stroke-width: 1;
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--fui-accent-glow, rgba(85, 230, 165, 0.55)) 100%, transparent));
+}
+
+.fui-ruler--compact .fui-ruler__ticks {
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--fui-accent-glow, rgba(85, 230, 165, 0.55)) 100%, transparent));
+}
+
+.fui-ruler__baseline {
+  stroke: color-mix(in srgb, var(--fui-accent, var(--hud-cyan)) 65%, transparent);
+  opacity: 0.85;
+}
+
+.fui-ruler__tick {
+  stroke: color-mix(in srgb, var(--fui-accent, var(--hud-cyan)) 90%, transparent);
+  opacity: 0.7;
+}
+
+.fui-ruler__tick--major {
+  stroke: color-mix(in srgb, var(--fui-accent, var(--hud-cyan)) 100%, transparent);
+  opacity: 0.95;
+}
+
+.fui-ruler__underbar {
+  fill: var(--fui-accent, var(--hud-cyan));
+  opacity: 0.92;
+}
+
+.fui-pill {
+  position: absolute;
+  top: 4px;
+  height: 20px;
+  padding: 0 10px;
+  border-radius: 999px;
+  backdrop-filter: blur(2px) saturate(120%);
+  border: 1px solid color-mix(in oklab, var(--fui-accent, var(--hud-cyan)) 35%, transparent);
+  background: color-mix(in oklab, var(--fui-accent, var(--hud-cyan)) 10%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fui-accent, var(--hud-cyan)) 22%, transparent);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.fui-pill--elevated {
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--fui-accent, var(--hud-cyan)) 28%, transparent),
+    0 4px 18px color-mix(in srgb, var(--fui-accent-glow, rgba(85, 230, 165, 0.55)) 65%, transparent);
+}
+
+.fui-ruler__label-layer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  padding-inline: var(--lane-padding, 14px);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.fui-ruler__label-layer--start {
+  justify-content: flex-start;
+}
+
+.fui-ruler__label-layer--center {
+  justify-content: center;
+}
+
+.fui-ruler__label-layer--end {
+  justify-content: flex-end;
+}
+
+.fui-ruler__label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding-inline: 4px;
+  font-family: var(--font-meta, 'Rajdhani', sans-serif);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  color: var(--hud-white);
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.45);
+  paint-order: stroke fill;
+  -webkit-font-smoothing: antialiased;
+}
+
+.fui-ruler__label::after {
+  content: '';
+  position: absolute;
+  inset-inline: -2px;
+  bottom: 2px;
+  height: 1px;
+  opacity: 0.3;
+  background: color-mix(in srgb, var(--fui-accent, var(--hud-cyan)) 35%, transparent);
+}
+
+.fui-ruler--underbar .fui-ruler__label::after {
+  opacity: 0;
+}
+
+.fui-ruler__label--elevated {
+  text-shadow:
+    0 0 6px rgba(0, 0, 0, 0.45),
+    0 0 12px color-mix(in srgb, var(--fui-accent-glow, rgba(85, 230, 165, 0.55)) 60%, transparent);
+}
+
+.fui-ruler[data-accent='mono'] .fui-ruler__label {
+  color: var(--hud-white);
+}
+
+.fui-ruler[data-variant='pill'] .fui-ruler__label {
+  text-shadow: 0 0 4px rgba(0, 0, 0, 0.55);
+}
+
 .fui-divider {
   position: relative;
   display: flex;
@@ -314,4 +459,16 @@
 
 .fui-callout[data-tone='mono'] {
   --fui-tone: var(--fui-mono);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fui-pill--elevated,
+  .fui-ruler__label--elevated {
+    box-shadow: none;
+    text-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
+  }
+
+  .fui-ruler__ticks {
+    filter: none;
+  }
 }


### PR DESCRIPTION
## Summary
- rebuild the HUD divider component with responsive ruler geometry and accent variants for improved readability
- add the supporting CSS variables and styles that render glowing tick marks and pill lanes for headers
- apply the refreshed divider styling to the home results and dossier telemetry sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2e1e7e5208329b23049dfbccfda10