### PR TITLE
Populate dossier AI summaries

### DIFF
--- a/public/data/index.json
+++ b/public/data/index.json
@@ -24,6 +24,7 @@
       "human",
       "cell"
     ],
+    "ai_summary": "Microgravity, defined by minimal gravitational forces, represents a unique environment that profoundly influences biological systems, including human cells. This review examines the effects of microgravity on biological processes and their implications for human health. Microgravity significantly impacts the immune system by disrupting key mechanisms, such as T cell activation, cytokine production, and macrophage differentiation, leading to increased susceptibility to infections.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -77,6 +78,7 @@
       "factors",
       "caused"
     ],
+    "ai_summary": "This review explores the biological impacts of SARS-CoV-2, the virus responsible for COVID-19, particularly focusing on post-acute sequelae and the resultant tissue and organ adaptations. As the virus continues to evolve, understanding its effects on human physiology is crucial for addressing the ongoing health crisis. The authors synthesize findings from virological, animal, and clinical studies to elucidate the mechanisms behind the diverse clinical manifestations observed in COVID-19 patients. Key findings reveal that SARS-CoV-2 leads to complex physiological changes that vary across different organ systems, highlighting the interplay between viral infection and host responses. The review emphasizes the need for further research to fill knowledge gaps and identifies potential biochemical targets for therapeutic intervention. By advancing our understanding of the virus's systemic effects, this work contributes to the broader field of space biosciences, where similar mechanisms may influence human health in extraterrestrial environments.",
     "access": [
       "PEER-REVIEWED",
       "ISS"
@@ -130,6 +132,7 @@
       "exploration",
       "travelers"
     ],
+    "ai_summary": "As non-governmental space exploration gains momentum, ethical considerations surrounding the selection of space travelers and the conduct of human subject research have become increasingly critical. This study highlights the pressing need for unified ethical guidelines to ensure the safety and well-being of a diverse array of space travelers participating in commercial and private missions. With initiatives like Inspiration4 and the Polaris missions transitioning from concept to reality, the absence of stringent governmental oversight raises concerns about ethical standards in medical research and decision-making in space. The authors emphasize the importance of establishing robust protocols that address the unique challenges posed by non-governmental operations, including the selection process for space travelers and the complexities of conducting medical research in such an environment. By advocating for comprehensive ethical frameworks, this research aims to safeguard human health and uphold the highest medical standards in the evolving landscape of space exploration, ensuring that future missions prioritize ethical integrity alongside scientific advancement.",
     "access": [
       "PEER-REVIEWED",
       "ISS"
@@ -194,6 +197,7 @@
       "ensmusg",
       "ensg"
     ],
+    "ai_summary": "This study investigates the impact of spaceflight on biomarkers associated with aging and frailty, addressing a critical gap in our understanding of astronaut health. By analyzing gene expression data from both murine models and astronauts involved in the JAXA and Inspiration4 missions, researchers sought to identify molecular changes indicative of frailty—a syndrome linked to biological aging. The analysis revealed significant alterations in the expression of frailty-related genes across various muscle tissues in mice during spaceflight, with notable upregulation observed in the gastrocnemius, extensor digitorum longus, quadriceps, soleus, and tibialis anterior muscles. These findings suggest that spaceflight may induce a frailty-like condition, paralleling changes seen in aging on Earth. Understanding these molecular shifts is vital for developing countermeasures to protect astronaut health during long-duration missions, ultimately enhancing the safety and effectiveness of human space exploration. This research underscores the importance of monitoring biological markers in space to mitigate health risks associated with prolonged exposure to microgravity.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -235,6 +239,7 @@
       "genes",
       "figure"
     ],
+    "ai_summary": "This study investigates the effects of spaceflight on muscle and liver tissues in mice, focusing on gene expression related to muscle atrophy and metabolic processes. Researchers analyzed the transcriptomes of liver and quadriceps from mice exposed to 37 days of microgravity during the NASA Rodent Research 1 mission. They discovered that lipid metabolism was significantly disrupted in both organs, with specific gene expression patterns in the liver linked to energy conservation mechanisms that influenced muscle gene expression related to atrophy. Notably, the study identified a correlation between impaired lipid metabolism and muscle atrophy, suggesting that these processes are interconnected during spaceflight. The findings highlight the physiological challenges posed by microgravity and suggest that dietary interventions could mitigate these effects, which is crucial for long-term human space exploration. Understanding these metabolic interactions is essential for developing strategies to preserve astronaut health in future missions.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -271,6 +276,7 @@
     "organism": null,
     "platform": null,
     "keywords": [],
+    "ai_summary": "This study investigates the impact of spaceflight on mouse liver metabolism, focusing on lipid dysregulation across multiple missions. Researchers employed a multi-omics approach, integrating genomics, transcriptomics, and metabolomics to analyze liver samples from mice exposed to space conditions. The scientific question centered on how microgravity and radiation affect metabolic processes, particularly lipid metabolism, which is crucial for understanding health risks in long-duration space missions. Key findings revealed consistent alterations in lipid profiles, indicating a theme of dysregulation that persisted across different missions. These changes could have implications for astronaut health, as lipid metabolism is linked to various diseases, including cardiovascular issues. The results underscore the need for further investigation into countermeasures that could mitigate these metabolic disruptions, ultimately contributing to safer and healthier space travel for future missions. This research enhances our understanding of biological responses to space environments, informing strategies to protect astronaut health during extended space exploration.",
     "access": [
       "PEER-REVIEWED"
     ],
@@ -305,6 +311,7 @@
       "fold",
       "samples"
     ],
+    "ai_summary": "Bone is a dynamically remodeled tissue that requires gravity-mediated mechanical stimulation for maintenance of mineral content and structure. Homeostasis in bone occurs through a balance in the activities and signaling of osteoclasts, osteoblasts, and osteocytes, as well as proliferation and differentiation of their stem cell progenitors. Microgravity and unloading are known to cause osteoclast-mediated bone resorption; however, we hypothesize that osteocytic osteolysis, and cell cycle arrest during osteogenesis may also contribute to bone loss in space.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -375,6 +382,7 @@
       "mirnas",
       "antagomir"
     ],
+    "ai_summary": "This study investigates the potential of targeting specific microRNAs (miRNAs) to mitigate the damaging effects of space radiation on human cells, a critical concern for long-duration space missions. Researchers focused on three miRNAs—miR-16-5p, miR-125b-5p, and let-7a-5p—using RNA sequencing and transcriptomic analysis on 3D microvessel cell cultures exposed to simulated Galactic Cosmic Radiation. The application of antagomirs, which inhibit these miRNAs, resulted in significant reductions in inflammation and DNA double strand breaks, alongside the restoration of mitochondrial function. Notably, the combination of all three antagomirs proved more effective than individual treatments. The findings were further supported by data from astronauts involved in NASA's Twin Study and other missions, demonstrating that the genes and pathways affected by these miRNAs are also altered in humans. This research offers a promising countermeasure strategy to protect astronauts from radiation damage, enhancing the safety and viability of future space exploration.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -415,6 +423,7 @@
       "growth",
       "host"
     ],
+    "ai_summary": "This study investigates how spaceflight and simulated microgravity conditions affect the virulence of the bacterium Serratia marcescens using the Drosophila melanogaster model. Researchers found that bacteria grown aboard the International Space Station exhibited significantly increased lethality compared to ground-based controls, with Drosophila survival rates markedly lower when infected with spaceflight-exposed strains. Notably, this heightened virulence did not persist once the bacteria were returned to Earth, indicating that the changes were likely temporary rather than genetic. Additionally, similar increases in virulence were observed in bacteria cultured under simulated microgravity conditions on Earth. The findings underscore the complex interplay between host immune responses and pathogen behavior in space environments, highlighting potential risks for astronaut health during long-duration missions. Understanding these dynamics is critical for developing effective countermeasures to protect astronauts from infections in space, thereby advancing the field of space biosciences.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -453,6 +462,7 @@
       "layers",
       "regions"
     ],
+    "ai_summary": "This study investigates the effects of galactic cosmic radiation (GCR) on DNA methylation patterns, focusing on how chromosomal positioning and epigenetic architecture influence cellular responses. Utilizing human bronchial epithelial cell data, researchers exposed cells to high-LET (56Fe, 28Si) and low-LET (X-ray) radiation. The results revealed that 56Fe significantly increases DNA methylation levels, while 28Si and X-ray radiation lead to transient decreases in methylation. Specifically, the study identified over 24,000 differentially methylated probes for various radiation types, highlighting the distinct epigenetic responses elicited by different radiation energies. The findings underscore the importance of nuclear chromatin architecture in mediating these responses, providing critical insights into the biological impacts of prolonged GCR exposure. This research is vital for understanding potential health risks associated with long-duration space missions, informing protective measures for astronauts and advancing the field of space biosciences.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -481,6 +491,7 @@
     "organism": null,
     "platform": null,
     "keywords": [],
+    "ai_summary": "This study investigates the role of the receptor-like kinase ERULUS in regulating root hair growth by maintaining tip-focused cytoplasmic calcium oscillations in plants. The researchers aimed to understand how ERULUS influences the spatial distribution of calcium signals, which are crucial for root hair development. Using a combination of genetic, biochemical, and imaging techniques, the team demonstrated that ERULUS localizes to the plasma membrane and is essential for proper calcium signaling in root hairs. They found that mutations in the ERULUS gene resulted in disrupted calcium oscillations, leading to impaired root hair growth. These findings highlight the importance of ERULUS in plant development and suggest that manipulating calcium signaling pathways could enhance root hair formation. This research has significant implications for space biosciences, as understanding plant growth mechanisms in microgravity could inform strategies for sustainable food production during long-duration space missions.",
     "access": [
       "PEER-REVIEWED"
     ],
@@ -508,6 +519,7 @@
       "arabidopsis",
       "file"
     ],
+    "ai_summary": "This study investigates the role of TNO1, a protein localized at the trans-Golgi network, in modulating root skewing in Arabidopsis thaliana. Root movement is crucial for plant anchorage and nutrient acquisition, and this research identifies TNO1 as a significant factor influencing this process. The researchers found that knockout mutants of TNO1 exhibited enhanced root skewing and epidermal cell file rotation, particularly when microtubules were stabilized, indicating a complex interaction between TNO1 and cytoskeletal dynamics. Interestingly, the skewing was unaffected by microtubule destabilization, suggesting that TNO1's influence on root growth is independent of microtubule orientation. Additionally, TNO1 is essential for maintaining cell morphology in mature root regions. These findings highlight the importance of the trans-Golgi network and associated proteins in root development, offering insights that could inform future research in space biosciences, particularly regarding plant growth in microgravity environments where root orientation and nutrient uptake are critical.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -543,6 +555,7 @@
       "arabidopsis",
       "file"
     ],
+    "ai_summary": "This study investigates the role of the TNO1 protein, localized at the trans-Golgi network, in regulating root skewing in *Arabidopsis thaliana*. The researchers aimed to understand how this protein influences root movement, which is crucial for plants to optimize nutrient acquisition and anchorage. They utilized knockout mutants of the TNO1 gene and observed that these mutants exhibited increased root skewing and altered epidermal cell file rotation. Notably, while the skewing intensified with microtubule stabilization, it remained unaffected by microtubule destabilization, indicating a complex relationship between TNO1 and microtubule dynamics. Furthermore, the study revealed that TNO1 is essential for maintaining cell morphology in mature root regions. These findings underscore the importance of TNO1 and the trans-Golgi network in root development, providing insights that could enhance our understanding of plant adaptability in varying environments, which is particularly relevant for space biosciences as we explore plant growth beyond Earth.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -585,6 +598,7 @@
       "truncatula",
       "cells"
     ],
+    "ai_summary": "This study investigates how brassinosteroids, specifically epi-brassinolide (eBL), influence root gravitropism in maize (Zea mays) by altering filamentous-actin (F-actin) dynamics. Gravitropism is the process where roots grow downward in response to gravity, and the researchers hypothesized that eBL enhances this response similarly to the actin inhibitor latrunculin B (LatB). Using a two-dimensional clinostat to simulate microgravity, the team treated maize roots with either eBL or LatB and observed their growth patterns. Both treatments resulted in enhanced downward growth and persistent curvature under clinorotation, indicating that eBL affects root directionality by modifying F-actin organization, albeit less dramatically than LatB. These findings are significant for space biosciences, as understanding plant responses to altered gravitational conditions is crucial for future space agriculture and the sustainability of long-term human missions beyond Earth.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -621,6 +635,7 @@
       "expressing",
       "time"
     ],
+    "ai_summary": "This study investigates the dynamics of cytoplasmic calcium ([Ca²⁺] cyt) signaling in different cell types of Arabidopsis thaliana seedling roots using genetically-encoded calcium indicators (GCaMP3). Recognizing that various root cell types may respond differently to environmental stimuli, the researchers developed lines expressing GCaMP3 in five specific cell types: columella, endodermis, cortex, epidermis, and trichoblasts. Through confocal microscopy, they observed distinct [Ca²⁺] cyt responses to treatments with ATP, glutamate, aluminum, and salt, revealing both similarities and differences in calcium signaling patterns among the cell types. Notably, the study found that the responses could be influenced by growth conditions, suggesting that methodological adjustments can enhance the reliability of calcium signaling measurements. These findings enhance our understanding of plant cellular responses to environmental changes, which is crucial for advancing space biosciences, particularly in developing resilient crops for long-duration space missions where environmental conditions can be unpredictable.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -644,6 +659,7 @@
     "organism": null,
     "platform": null,
     "keywords": [],
+    "ai_summary": "This study investigates the phenomenon of horizontal gene transfer (HGT) in tardigrades, microscopic organisms known for their resilience in extreme environments, including space. Researchers analyzed the draft genome of a tardigrade and identified extensive gene transfer from various sources, including bacteria and archaea. Using advanced genomic techniques, they compared the tardigrade genome to those of other organisms, revealing that approximately 17% of its genes originated from external sources, highlighting the organism's unique evolutionary adaptations. These findings suggest that HGT plays a significant role in the genetic diversity and survival mechanisms of tardigrades, particularly in extreme conditions. Understanding these processes is crucial for space biosciences, as it may inform how life can adapt to extraterrestrial environments, potentially aiding in future astrobiological research and the search for life beyond Earth. This study underscores the importance of microbial interactions in shaping the genetic landscape of extremophiles, which could have implications for the development of biotechnological applications in space exploration.",
     "access": [
       "PEER-REVIEWED"
     ],
@@ -675,6 +691,7 @@
       "biology",
       "program"
     ],
+    "ai_summary": "NASA's Space Biology and Human Research Program is advancing translational research to enhance human exploration and habitation missions. The study emphasizes the importance of collaborative efforts across various scientific disciplines to address the unique challenges posed by long-duration space travel. It highlights recent examples of early-stage translational research sponsored by NASA, showcasing innovative approaches that bridge laboratory findings with real-world applications in space environments. Key findings suggest that fostering interdisciplinary partnerships can accelerate the development of solutions that ensure astronaut health and performance during missions. This research is crucial for preparing for future explorations, such as missions to Mars, where understanding biological responses to space conditions is essential. By advocating for a structured approach to translational research, NASA aims to streamline the path from scientific discovery to practical implementation, ultimately contributing to the success and safety of human spaceflight endeavors.",
     "access": [
       "PEER-REVIEWED"
     ],
@@ -732,6 +749,7 @@
       "gene",
       "genes"
     ],
+    "ai_summary": "This study explored the effects of varying gravitational conditions—microgravity, lunar gravity (1/6 g), and Earth gravity (1 g)—on the skeletal and immune systems of C57BL/6J mice during a 25-35 day mission aboard the International Space Station. Researchers aimed to understand how these environments impact bone density, thymus health, and immune function. Key findings revealed that while microgravity led to significant bone density loss and thymus atrophy, recovery was observed when mice were subjected to 1 g, with partial recovery under lunar gravity. Gene expression related to bone health and immune response showed alterations, indicating that lunar gravity can mitigate some adverse effects of microgravity. Notably, while histological changes were absent in the spleen, gene expression variations were detected. These results highlight the importance of gravitational conditions in space travel, providing insights that could inform future human space missions and the development of countermeasures to protect astronaut health in long-duration spaceflights.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -758,6 +776,7 @@
     "organism": null,
     "platform": null,
     "keywords": [],
+    "ai_summary": "This study addresses the challenge of identifying foreign genes in the genome assemblies of the extremophilic tardigrade Hypsibius dujardini, which is crucial for understanding its unique biological resilience. The authors critically respond to previous analyses by Bemm et al. and Arakawa, highlighting discrepancies in gene identification methods. They utilized advanced genomic techniques to distinguish between native and foreign genetic material, focusing on the implications for evolutionary biology and astrobiology. Key findings reveal that a significant portion of the genome may originate from horizontal gene transfer, suggesting that these foreign genes contribute to the organism's survival in extreme environments. This research underscores the importance of accurate genomic analysis in space biosciences, as understanding the genetic adaptations of tardigrades could inform the search for life beyond Earth and the development of resilient biological systems for future space exploration. The study emphasizes the need for refined methodologies in genomic research to enhance our comprehension of life's adaptability in extraterrestrial contexts.",
     "access": [
       "PEER-REVIEWED"
     ],
@@ -786,6 +805,7 @@
       "system",
       "not"
     ],
+    "ai_summary": "This study evaluates the \"FAIRness\" of NASA's GeneLab Data Systems (GLDS) and four comparable omics data systems, focusing on their ability to share and integrate biological data effectively. Using 14 FAIRness metrics, the researchers found that the systems scored between 6 and 12, with an average score of 10.1, indicating moderate performance in data sharing. Notably, while data findability and accessibility were rated relatively high, interoperability was a significant weakness, with many systems failing to support the reusability of metadata. These findings highlight critical gaps in data integration capabilities, which are essential for advancing research in space biosciences. The study emphasizes the need for improved interoperability and proposes two new principles for developers to enhance data accessibility. By addressing these issues, the research aims to foster collaborative investigations that can better support biomedical research relevant to both space exploration and terrestrial applications.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -824,6 +844,7 @@
       "marker",
       "protein"
     ],
+    "ai_summary": "This study investigates a novel protein in *Arabidopsis thaliana*, named AtGTLP (Arabidopsis thaliana Glycosyl Transferase-Like Protein), which is predicted to function as a glycosyltransferase. The research focused on the protein's subcellular localization, particularly its interaction with the trans-Golgi network-localized Qa-SNARE, SYNTAXIN OF PLANTS 43. Using fluorescence microscopy, the authors established that AtGTLP predominantly localizes to the Golgi apparatus, featuring a type II membrane topology with a single transmembrane helix and a globular C-terminal domain. Despite the absence of observable phenotypic differences in atgtlp−/− mutants, the findings suggest that AtGTLP may belong to an uncharacterized family of fucosyltransferases in plants. Understanding the role of AtGTLP enhances our knowledge of membrane trafficking and glycosylation processes, which are crucial for plant development and could have implications for biotechnological applications and space biosciences, where plant resilience and adaptation in extraterrestrial environments are of interest.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -870,6 +891,7 @@
       "group",
       "experiment"
     ],
+    "ai_summary": "After a 16-year hiatus, Russia has resumed its program of biomedical research in space, with the successful 30-day flight of the Bion-M 1 biosatellite (April 19–May 19, 2013). The principal species for biomedical research in this project was the mouse. This paper presents an overview of the scientific goals, the experimental design and the mouse training/selection program.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -907,6 +929,7 @@
       "growth",
       "mutant"
     ],
+    "ai_summary": "The study investigates the roles of AtRabD2b and AtRabD2c, two Rab GTPases, in pollen development and tube growth in Arabidopsis thaliana. While single mutants of each gene show no significant morphological differences from wild-type plants, the double mutant (AtrabD2b/2c) exhibits shorter siliques and produces deformed pollen with swollen, branched tube tips. These defects in pollen morphology lead to reduced fertility, highlighting the critical role of these proteins in pollen function. Both AtRabD2b and AtRabD2c are highly expressed in pollen and localize to Golgi bodies, suggesting their involvement in vesicle trafficking essential for pollen tube growth. The findings indicate that AtRabD2b and AtRabD2c have overlapping functions, emphasizing the importance of Rab GTPases in plant reproduction. Understanding these mechanisms is vital for advancing space biosciences, particularly in developing plants for long-duration space missions where successful reproduction is crucial for sustainability.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -948,6 +971,7 @@
       "bone",
       "was"
     ],
+    "ai_summary": "This study investigates the impact of space-like radiation on bone health, specifically focusing on how different types and doses of ionizing radiation affect osteoblastogenesis in mice. Researchers hypothesized that exposure to radiation would impair the formation of bone cells (osteoblasts) in a manner dependent on the type of ionizing radiation and its dose. Male C57BL6/J mice were exposed to low-linear-energy-transfer (LET) protons and high-LET iron ions at varying doses. Results indicated that high doses (200 cGy) of both radiation types significantly impaired osteoblastogenesis and altered bone microarchitecture, while lower doses had a modulating effect on redox-related gene expression. These findings highlight the potential risks of space radiation on skeletal health, particularly as it relates to aging in astronauts. Understanding these mechanisms is crucial for developing countermeasures to protect bone health during long-duration space missions, thereby enhancing astronaut safety and mission success.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -983,6 +1007,7 @@
       "seedlings",
       "mutant"
     ],
+    "ai_summary": "This study investigates the role of the trans-Golgi network protein TNO1 in auxin transport and root development in Arabidopsis thaliana. Researchers found that the tno1 mutant exhibited significant defects in lateral root emergence and gravitropic responses, indicating that TNO1 is crucial for these processes. Specifically, the mutant roots showed delayed auxin transport during gravistimulation and reduced auxin asymmetry at the tips of elongating lateral roots. Despite these defects, endocytosis to the trans-Golgi network was unaffected, suggesting that TNO1's role is specific to auxin-related signaling rather than general trafficking issues. The findings highlight TNO1's importance in mediating auxin-dependent root architecture, which is vital for plant adaptation and growth. Understanding these mechanisms is essential for advancing space biosciences, particularly in developing strategies for plant growth in microgravity environments, where efficient root development and nutrient transport are critical for sustaining life.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1022,6 +1047,7 @@
       "loading",
       "specimen"
     ],
+    "ai_summary": "This study addresses the challenge of assessing bone quality in small animals, specifically the response of mouse vertebrae to cyclic mechanical loading. The researchers developed a high-precision method for ex vivo cyclic compressive loading of isolated mouse vertebral bodies, utilizing 3D-printed support jigs, pivotable loading platens, and micro-CT-based finite element analysis to ensure consistent strain across specimens. Testing the new method against two established techniques, the results indicated that the new approach (K FEA method) significantly reduced variability in fatigue life, with an 8-fold lower standard deviation compared to the existing methods. This precision led to a uniform fatigue life across specimens, contrasting with the negative correlation observed in the literature methods. These findings are crucial for space biosciences, as understanding bone behavior under mechanical stress is vital for assessing the impacts of microgravity on skeletal health during long-duration space missions.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1061,6 +1087,7 @@
       "ben",
       "latb"
     ],
+    "ai_summary": "This study investigates the role of the HYPERSENSITIVE TO LATRUNCULIN B1 (HLB1) protein in Arabidopsis thaliana, focusing on its function within the endomembrane system, crucial for plant development. HLB1, identified through a forward-genetic screen, is a tetratricopeptide repeat domain-containing protein that associates with the trans-Golgi network and early endosomes, suggesting its involvement in linking post-Golgi traffic to the actin cytoskeleton. The researchers discovered that hlb1 mutants exhibited increased sensitivity to actin-disrupting drugs, such as latrunculin B and cytochalasins, leading to impaired root growth. Genetic analysis revealed that HLB1 operates in conjunction with the MIN7/BEN1 protein, which is also involved in endocytic trafficking. These findings highlight the importance of HLB1 in maintaining cellular organization and transport processes in plants. Understanding such mechanisms is vital for advancing space biosciences, particularly in developing resilient plant systems for long-duration space missions, where effective nutrient transport and growth are essential for sustainability.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1104,6 +1131,7 @@
       "gfp",
       "localization"
     ],
+    "ai_summary": "This study investigates the role of the Drosophila SUN protein Spag4 in maintaining the attachment between centrioles and nuclei during spermatogenesis. The researchers found that Spag4 is specifically expressed in the testes and is crucial for the association of the single spermatid centriole with the spermatid nucleus. In the absence of Spag4, a dissociation occurs post-meiosis, indicating its essential function in cellular organization. The study highlights that Spag4's action does not depend on the KASH proteins present in Drosophila but requires the coiled-coil protein Yuri Gagarin, which localizes similarly to Spag4 at the nuclear surface. These findings enhance our understanding of LINC complex dynamics and centrosome-nucleus interactions, which are vital for proper cellular function. This research has implications for space biosciences, as understanding these mechanisms can inform how cellular processes are affected in microgravity environments, potentially impacting reproductive health and development in space.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1145,6 +1173,7 @@
       "genes",
       "video"
     ],
+    "ai_summary": "This study investigates antimicrobial resistance (AMR) within the microbiome of the International Space Station (ISS), a critical concern for long-duration space missions. Utilizing shotgun metagenomics data from the Microbial Tracking–1 project, researchers analyzed samples from various ISS locations over 12 months, focusing on 226 cultivable strains and metagenome-assembled genomes (MAGs). By employing a deep learning model, the study identified a broader range of AMR genes than traditional methods, revealing a significant presence of AMR in the bacterium Kalamiella piersonii during the last flight. Notably, strains of Enterobacter bugandensis and Bacillus cereus exhibited high resistance to beta-lactam antibiotics, confirmed through experimental validation. These findings underscore the potential risks posed by AMR in space environments, emphasizing the need for ongoing monitoring and strategies to mitigate microbial threats during future space exploration. The research enhances our understanding of the ISS microbiome and its implications for human health in extraterrestrial settings.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1207,6 +1236,7 @@
       "mouse",
       "assay"
     ],
+    "ai_summary": "The International Space Station (ISS) National Laboratory is dedicated to studying the effects of space on life and physical systems, and to developing new science and technologies for space exploration. A key aspect of achieving these goals is to operate the ISS National Lab more like an Earth-based laboratory, conducting complex end-to-end experimentation, not limited to simple microgravity exposure. Towards that end NASA developed a novel suite of molecular biology laboratory tools, reagents, and methods, named WetLab-2, uniquely designed to operate in microgravity, and to process biological samples for real-time gene expression analysis on-orbit.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1244,6 +1274,7 @@
       "oxidative",
       "grd"
     ],
+    "ai_summary": "This study investigates how spaceflight affects the expression of genes related to oxidative stress and cell cycle regulation in the heart, addressing a critical gap in understanding cardiovascular changes during extended space missions. Mice were flown on the Space Shuttle Discovery for 15 days, with their cardiac tissue analyzed post-flight. The results revealed that spaceflight significantly altered the expression of 37 out of 168 examined genes. Notably, the transcription factor Nfe2l2 (Nrf2) was downregulated, while genes associated with oxidative stress, such as Nox1 and Ptgs2, showed increased expression. Additionally, cell cycle-related genes, including Cdkn1a (p21) and Myc, were upregulated. These molecular changes suggest a persistent state of oxidative stress and may contribute to cardiac dysfunction observed in astronauts. Understanding these mechanisms is crucial for developing countermeasures to protect cardiovascular health during long-duration spaceflight, ultimately aiding future exploration missions and enhancing astronaut safety.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1284,6 +1315,7 @@
       "figure",
       "tip"
     ],
+    "ai_summary": "This study investigates the roles of SPIRRIG (SPI) and components of the WAVE/SCAR (W/SC) complex in the development of root hairs in Arabidopsis thaliana, focusing on their spatial and temporal localization. Root hairs are crucial for nutrient and water absorption, achieving their shape through a process known as tip growth, which relies on the coordination of the actin cytoskeleton and endomembrane systems. The researchers found that SPI localizes at the apex of root hairs, promoting tip growth by facilitating vesicle secretion and maintaining actin integrity. In contrast, W/SC components BRK1 and SCAR2 mark the initiation domain for root hair emergence. Mutants lacking SPI exhibited reduced tip growth, while those deficient in BRK1 and SCAR2 showed disrupted hair positioning. These findings enhance our understanding of cellular mechanisms governing root hair development, which is vital for optimizing plant growth in various environments, including space, where resource efficiency is critical for sustaining life.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1323,6 +1355,7 @@
       "shown",
       "current"
     ],
+    "ai_summary": "This study investigates the modulation of the MscL mechanosensitive channel, a bacterial protein that protects cells from lysis during osmotic stress. MscL's ability to be genetically modified positions it as a potential nanovalve for applications in microelectronics and targeted drug delivery. The researchers explored three methods to adjust the channel's conductance: shortening the linker between the transmembrane and cytoplasmic domains, cross-linking, and heavy metal coordination. Their findings reveal that these modifications effectively reduce channel conductance, with some changes being reversible. Notably, the stability of the cytoplasmic bundle remains intact during channel gating, suggesting that the MscL can be engineered to create smaller pore sizes. This research not only enhances our understanding of mechanosensitive channels but also opens avenues for developing more adaptable biosensors and nanotechnology devices, which could have significant implications for space biosciences and other fields requiring precise control of molecular transport.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1358,6 +1391,7 @@
       "arabidopsis",
       "plants"
     ],
+    "ai_summary": "This study investigates the role of TNO1, a protein interacting with the soluble N-ethylmaleimide-sensitive factor attachment protein receptor SYP41, in Arabidopsis thaliana. Researchers aimed to understand how TNO1 contributes to salt tolerance and vacuolar trafficking. Utilizing coimmunoprecipitation and immunofluorescence microscopy, TNO1 was localized to the trans-Golgi network (TGN). The tno1 mutant exhibited heightened sensitivity to various salts and osmotic stress, indicating a compromised stress response. Notably, the localization of SYP61, which plays a critical role in salt stress, was disrupted in the mutant. Additionally, the tno1 mutant showed impaired vacuolar protein trafficking, as evidenced by the secretion of vacuolar proteins to the apoplast and delayed formation of the brefeldin A compartment. These findings highlight TNO1's essential function in vesicle fusion and stress tolerance, providing insights that could inform strategies for enhancing plant resilience in extreme environments, including those encountered in space exploration.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1426,6 +1460,7 @@
       "cell",
       "spaceflight"
     ],
+    "ai_summary": "This study investigates a microRNA (miRNA) signature linked to spaceflight, revealing critical insights for countermeasure development in space biosciences. Researchers identified a shared miRNA response in rodents and humans exposed to simulated short- and long-duration spaceflight conditions. Utilizing data from the NASA Twins Study, they confirmed the expression of specific miRNAs through advanced sequencing techniques. Notably, miR-125, miR-16, and let-7a were found to mitigate vascular damage induced by simulated deep space radiation. The study employed antagomirs to inhibit these miRNAs, demonstrating their physiological relevance by successfully rescuing damage in human 3D vascular constructs. These findings underscore the potential of targeting miRNA pathways to develop therapeutic strategies for protecting astronauts from the adverse effects of spaceflight, enhancing human health during long-duration missions. This research paves the way for future investigations into miRNA-based countermeasures, contributing significantly to the field of space biosciences.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1476,6 +1511,7 @@
       "heart",
       "herg"
     ],
+    "ai_summary": "This study investigates the impact of microgravity on cardiac function using Drosophila as a model organism, given the conservation of heart structure between flies and humans. Researchers exposed flies to microgravity aboard the International Space Station and observed significant cardiac constriction, myofibrillar remodeling, and reduced heart output. RNA sequencing of isolated hearts revealed decreased expression of sarcomeric and extracellular matrix genes alongside increased proteasomal gene expression, indicating disrupted proteostasis. Further analysis showed elevated proteasome aggregates associated with amyloid and polyglutamine deposits. Notably, in long-QT syndrome mutants, proteasomal gene expression increased in microgravity, albeit at lower levels than in wild-type flies. These findings highlight that prolonged microgravity induces cardiac remodeling and proteostatic stress, which are critical for understanding potential health risks for astronauts during long-duration space missions. This research provides insights into the fundamental biological responses of heart muscle in microgravity, informing future space bioscience studies and human health in space exploration.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1512,6 +1548,7 @@
       "eco-mscl",
       "kinetics"
     ],
+    "ai_summary": "This study investigates the mechanosensitive channel MscL, a critical protein in bacterial osmoregulation, by examining chimeras derived from E. coli and S. aureus. The research focuses on a specific residue at the periplasmic lipid-aqueous interface, notably E. coli I49 and its S. aureus equivalent F47, which significantly impacts channel kinetics and mechanosensitivity. Using electrophysiological techniques, the authors demonstrated that variations in this region alter the open dwell time and the threshold for channel activation. One mutant exhibited pronounced hysteresis, underscoring the residue's role in channel gating dynamics. The findings suggest that this lipid-interface residue functions like a spring, modulating the energy barriers for channel opening and closure. Understanding these mechanisms is crucial for advancing our knowledge of how cells sense and respond to mechanical stimuli, which has implications for developing biosensors and therapeutic strategies in space biosciences, where microbial behavior under altered gravitational conditions is of particular interest.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1551,6 +1588,7 @@
       "activation",
       "phosphorylation"
     ],
+    "ai_summary": "This study investigates the role of γ-sarcoglycan in mechanotransduction signaling within skeletal muscle, particularly focusing on p70S6 kinase (p70S6K) responses to mechanical stretch. The research highlights that the absence of γ-sarcoglycan, a component of the dystrophin glycoprotein complex, leads to significant alterations in signaling pathways that are crucial for muscle function. Using C2C12 myotubes and muscle samples from both wild-type and γ-sarcoglycan-null mice, the authors found that stretching induced a robust activation of p70S6K in normal muscle, whereas this response was absent in γ-sarcoglycan-null samples. Notably, while p70S6K activation was calcium-independent in γ-sarcoglycan-null muscles, it remained elevated even under conditions that typically reduce its activation. These findings suggest that γ-sarcoglycan is essential for the normal mechanotransduction response, and its absence disrupts load-sensing mechanisms, potentially contributing to the pathophysiology of muscular dystrophies. This research has implications for understanding muscle degeneration and developing targeted therapies in space biosciences and beyond.",
     "access": [
       "PEER-REVIEWED",
       "MUSCULOSKELETAL ADAPTATION"
@@ -1585,6 +1623,7 @@
       "cytoskeleton",
       "light"
     ],
+    "ai_summary": "This review explores the critical role of the actin cytoskeleton in the growth of primary roots, which are essential for plant stability and nutrient acquisition. The authors highlight how efficient root elongation and bending rely on a complex interplay of environmental sensing, hormonal signaling, and growth responses, all mediated by the actin network. They discuss the influence of actin-binding proteins and plant hormones on root development, as well as the effects of actin-disrupting drugs. A key finding is the identification of longitudinally oriented actin bundles as vital for cell elongation, along with the actin cytoskeleton's involvement in protein trafficking and vacuolar reshaping. The review also emphasizes the feedback mechanisms between actin organization and root responses to light and gravity. Understanding these processes is crucial for advancing space biosciences, as it can inform strategies for optimizing plant growth in extraterrestrial environments, where resource availability and environmental conditions differ significantly from Earth.",
     "access": [
       "PEER-REVIEWED",
       "SPACE BOTANY"
@@ -1624,6 +1663,7 @@
       "figure",
       "strength"
     ],
+    "ai_summary": "This study investigates the impact of ionizing radiation on the structural integrity and mechanical properties of mouse vertebrae, focusing on the roles of collagen fragmentation and non-enzymatic crosslinking. Using ex vivo x-ray radiation on lumbar vertebrae from female C57BL/6J mice, researchers exposed samples to doses ranging from 0 to 35,000 Gy. Key findings revealed that vertebral strength, ultimate strain, and work-to-fracture significantly decreased at higher radiation doses (17,000 and 35,000 Gy), with strength reduced by 50% and 73%, respectively, compared to controls. In contrast, collagen fragmentation was more closely associated with these mechanical changes than non-enzymatic crosslinking. These results underscore the detrimental effects of high radiation exposure on bone quality, highlighting potential risks for astronauts during long-duration space missions. Understanding these mechanisms is crucial for developing strategies to mitigate bone loss and maintain skeletal health in space environments.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1677,6 +1717,7 @@
       "impact",
       "reproductive"
     ],
+    "ai_summary": "This review examines the potential risks of gynecological cancers in female astronauts due to the unique challenges of spaceflight, particularly microgravity and ionizing radiation from galactic cosmic rays. Historically, women have had limited opportunities for long-duration space missions due to their higher susceptibility to radiation-induced cancers, including breast and ovarian cancers. The authors highlight a significant gap in research regarding the effects of space conditions on the female reproductive system, noting that current data is insufficient to assess the risks accurately. As upcoming Artemis missions aim to send women to the Moon for extended periods, it is crucial to understand how prolonged exposure to microgravity and radiation may influence gynecological cancer risks. The findings underscore the need for targeted studies to ensure the safety and health of female astronauts, particularly in light of their heightened vulnerability to radiation. This research is vital for developing effective screening and management strategies for women in space exploration.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1715,6 +1756,7 @@
       "are",
       "gene"
     ],
+    "ai_summary": "This study investigates the long-term effects of space radiation on cardiovascular health, a growing concern for astronauts. Utilizing data from NASA's GeneLab database, researchers employed a systems biology approach to identify key molecular pathways influenced by space radiation. They compared microarray data from cardiomyocytes of male C57BL/6 mice exposed to simulated space radiation with human endothelial cells cultured on the International Space Station (ISS). The findings revealed that the FYN gene plays a pivotal role in the cardiovascular response to radiation, suggesting that initial oxidative stress is transient and leads to FYN upregulation, which subsequently reduces reactive oxygen species (ROS) levels. This protective mechanism highlights potential strategies for mitigating cardiovascular risks in astronauts. Understanding these molecular responses is crucial for developing countermeasures to safeguard astronaut health during long-duration space missions, ultimately enhancing the safety and success of future explorations beyond Earth.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1750,6 +1792,7 @@
       "spermine",
       "pore"
     ],
+    "ai_summary": "This study investigates the MscL channel, a bacterial mechanosensor that acts as a biological valve for solute release during osmotic downshock, to explore its potential as a nanovalve for targeted drug delivery. Researchers introduced charged compounds into the MscL pore lumen to assess their impact on the permeation of large charged molecules. Using in vivo assays and electrophysiological techniques, they discovered that the presence of a charge significantly influences the channel's permeability, revealing an unexpected anionic preference in wild-type MscL. The findings indicate that MscL can be engineered to function as a controllable nanoswitch, responding to external stimuli like light or pH. This research has critical implications for space biosciences, as it enhances the understanding of how to manipulate biological systems for drug delivery in microgravity environments, potentially improving therapeutic strategies for astronauts and advancing biotechnological applications.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1795,6 +1838,7 @@
       "dose",
       "each"
     ],
+    "ai_summary": "This study investigates the biological responses of animal models to space radiation, particularly focusing on the effects of galactic cosmic rays (GCR) on astronaut health during extended missions. Utilizing the extensive NASA GeneLab database, researchers analyzed multiple omics datasets from both ground-based and spaceflight experiments, examining radiation exposure across various ion types and doses. Key findings revealed distinct biological signatures linked to specific ions, highlighting dose-dependent changes in mitochondrial function, ribosomal assembly, and immune pathways. The analysis encompassed data from diverse tissues, providing insights into the cellular mechanisms affected by radiation. This research underscores the potential risks posed by ionizing radiation in space environments and demonstrates how GeneLab's comprehensive resources can enhance our understanding of these effects, ultimately informing strategies to safeguard astronaut health during long-duration space missions. The findings are crucial for advancing space biosciences and developing effective countermeasures against radiation exposure.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1833,6 +1877,7 @@
       "oligomeric",
       "state"
     ],
+    "ai_summary": "This study investigates the oligomeric state of the mechanosensitive channel MscL from Staphylococcus aureus (SaMscL), a critical protein that senses membrane tension. Previous research indicated conflicting models, suggesting SaMscL could exist as a tetramer or a pentamer. Using a novel disulfide-trapping technique, the researchers determined that SaMscL predominantly forms pentamers in vivo, establishing this configuration as the physiologically relevant state. In vitro analyses revealed that detergent solubilization could alter the oligomeric state, shifting from pentamers to tetramers. These findings underscore the importance of environmental conditions on protein structure and function, which is crucial for understanding mechanosensation in bacteria and potentially in higher organisms. This research not only clarifies the structural biology of MscL but also highlights the implications for studying membrane proteins in various contexts, including space biosciences, where understanding cellular responses to mechanical forces is vital for long-duration missions.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1873,6 +1918,7 @@
       "ssea-",
       "was"
     ],
+    "ai_summary": "Therapeutic effects of adult stem-cell transplantations are limited by poor cell-retention in target organs, and a reduced potential for optimal cell differentiation compared to embryonic stem cells. However, contemporary studies have indicated heterogeneity within adult stem-cell pools, and a novel culturing technique may address these limitations by selecting those for cell proliferation which are highly functional. Here, we report the preservation of stemness in human adipose-derived stem cells (hASCs) by using microgravity conditions combined with microspheres in a stirred suspension.",
     "access": [
       "PEER-REVIEWED",
       "ISS",
@@ -1909,6 +1955,7 @@
       "activity",
       "was"
     ],
+    "ai_summary": "This study investigates the protein-protein interactions between the S1 region and the cytoplasmic interface of TM2 in the mechanosensitive channel MscL, which plays a crucial role in bacterial osmoregulation. Using an in vivo disulfide trapping assay on 143 double-cysteine mutants of E. coli MscL, researchers mapped interactions that occur as the channel transitions from a closed to an open state. The results revealed that the S1 and TM2 ci domains interact very efficiently, requiring minimal oxidizing agent to facilitate disulfide bond formation, indicating strong coupling between these regions during gating. This work enhances our understanding of how MscL senses mechanical stimuli and opens in response to osmotic changes, providing insights into the fundamental mechanisms of mechanotransduction in cells. Such knowledge is vital for advancing space biosciences, where understanding protein behavior under altered gravitational and osmotic conditions can inform the development of life-support systems and biotechnological applications in space exploration.",
     "access": [
       "PEER-REVIEWED",
       "Space Shuttle",
@@ -1944,6 +1991,7 @@
       "mscs",
       "mscl"
     ],
+    "ai_summary": "Single-celled organisms face extreme environmental challenges, particularly rapid decreases in external osmolarity, which can lead to dangerous internal pressure build-up. To prevent cell lysis, many microbes utilize mechanosensitive channels, specifically the MscS and MscL families, which function as emergency release valves to expel cytoplasmic solutes. This study explores the roles of these channels, revealing that while they are crucial for microbial survival, their presence in plant organelles and various fungi complicates the understanding of their physiological functions. By comparing MscS and MscL, the research highlights their structural and functional models, emphasizing their significance beyond simple osmotic regulation. These findings are vital for space biosciences, as understanding microbial resilience mechanisms can inform strategies for life support systems in extraterrestrial environments, where organisms may encounter similar osmotic stressors.",
     "access": [
       "PEER-REVIEWED",
       "SPACE BOTANY"
@@ -1979,6 +2027,7 @@
       "c-terminal",
       "used"
     ],
+    "ai_summary": "This study investigates the oligomeric state of the mechanosensitive channel of large conductance (MscL) from Staphylococcus aureus, a protein crucial for cell survival during osmotic stress. Previous research indicated conflicting oligomeric structures—pentameric and tetrameric—based on crystallization methods. To clarify this, the authors employed an in vivo disulfide-trapping technique to analyze various C-terminal truncations of MscL. The findings confirm that the full-length S. aureus MscL exists as a pentamer in native membranes, aligning with recent studies that challenge earlier interpretations of its tetrameric form. This research highlights the influence of protein manipulation on oligomeric state determinations and underscores the importance of studying proteins in their native environments. Understanding the structural dynamics of MscL is vital for advancing space biosciences, as it may inform strategies for engineering resilient microbial life for long-duration space missions, where osmotic challenges are prevalent.",
     "access": [
       "PEER-REVIEWED",
       "Space Shuttle",
@@ -2027,6 +2076,7 @@
       "toll",
       "immune"
     ],
+    "ai_summary": "This study investigates how gravity and spaceflight affect immune responses in Drosophila, focusing on the Toll signaling pathway, which is crucial for fighting infections. Given that human immune function deteriorates in microgravity, understanding these mechanisms is vital for astronaut health. The researchers exposed Drosophila to hypergravity conditions and assessed their survival after infection with the pathogenic fungus Beauveria bassiana. Results showed that hypergravity significantly enhanced survival rates across various fly strains, suggesting that increased gravitational forces may bolster immune responses. Conversely, spaceflight altered gene transcription related to immune function, indicating that microgravity may impair these responses. These findings highlight the complex interplay between gravity and immune function, underscoring the need for further research to develop effective countermeasures for maintaining astronaut health during long-duration space missions. Understanding these biological responses is critical for ensuring the safety and well-being of future space explorers.",
     "access": [
       "PEER-REVIEWED",
       "ISS",

--- a/public/data/papers/exp_001.json
+++ b/public/data/papers/exp_001.json
@@ -39,6 +39,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4136787/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4136787/pdf/pone.0104830.pdf"
   },
+  "ai_summary": "After a 16-year hiatus, Russia has resumed its program of biomedical research in space, with the successful 30-day flight of the Bion-M 1 biosatellite (April 19–May 19, 2013). The principal species for biomedical research in this project was the mouse. This paper presents an overview of the scientific goals, the experimental design and the mouse training/selection program.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_002.json
+++ b/public/data/papers/exp_002.json
@@ -35,6 +35,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3630201/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3630201/pdf/pone.0061372.pdf"
   },
+  "ai_summary": "Bone is a dynamically remodeled tissue that requires gravity-mediated mechanical stimulation for maintenance of mineral content and structure. Homeostasis in bone occurs through a balance in the activities and signaling of osteoclasts, osteoblasts, and osteocytes, as well as proliferation and differentiation of their stem cell progenitors. Microgravity and unloading are known to cause osteoclast-mediated bone resorption; however, we hypothesize that osteocytic osteolysis, and cell cycle arrest during osteogenesis may also contribute to bone loss in space.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_003.json
+++ b/public/data/papers/exp_003.json
@@ -33,6 +33,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11988870/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11988870/pdf/ijms-26-03058.pdf"
   },
+  "ai_summary": "Microgravity, defined by minimal gravitational forces, represents a unique environment that profoundly influences biological systems, including human cells. This review examines the effects of microgravity on biological processes and their implications for human health. Microgravity significantly impacts the immune system by disrupting key mechanisms, such as T cell activation, cytokine production, and macrophage differentiation, leading to increased susceptibility to infections.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_004.json
+++ b/public/data/papers/exp_004.json
@@ -33,6 +33,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7998608/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7998608/pdf/cells-10-00560.pdf"
   },
+  "ai_summary": "Therapeutic effects of adult stem-cell transplantations are limited by poor cell-retention in target organs, and a reduced potential for optimal cell differentiation compared to embryonic stem cells. However, contemporary studies have indicated heterogeneity within adult stem-cell pools, and a novel culturing technique may address these limitations by selecting those for cell proliferation which are highly functional. Here, we report the preservation of stemness in human adipose-derived stem cells (hASCs) by using microgravity conditions combined with microspheres in a stirred suspension.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_005.json
+++ b/public/data/papers/exp_005.json
@@ -55,6 +55,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5587110/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5587110/pdf/pone.0183480.pdf"
   },
+  "ai_summary": "The International Space Station (ISS) National Laboratory is dedicated to studying the effects of space on life and physical systems, and to developing new science and technologies for space exploration. A key aspect of achieving these goals is to operate the ISS National Lab more like an Earth-based laboratory, conducting complex end-to-end experimentation, not limited to simple microgravity exposure. Towards that end NASA developed a novel suite of molecular biology laboratory tools, reagents, and methods, named WetLab-2, uniquely designed to operate in microgravity, and to process biological samples for real-time gene expression analysis on-orbit.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_006.json
+++ b/public/data/papers/exp_006.json
@@ -30,6 +30,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8396460/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8396460/pdf/ijms-22-09088.pdf"
   },
+  "ai_summary": "This study investigates how spaceflight affects the expression of genes related to oxidative stress and cell cycle regulation in the heart, addressing a critical gap in understanding cardiovascular changes during extended space missions. Mice were flown on the Space Shuttle Discovery for 15 days, with their cardiac tissue analyzed post-flight. The results revealed that spaceflight significantly altered the expression of 37 out of 168 examined genes. Notably, the transcription factor Nfe2l2 (Nrf2) was downregulated, while genes associated with oxidative stress, such as Nox1 and Ptgs2, showed increased expression. Additionally, cell cycle-related genes, including Cdkn1a (p21) and Myc, were upregulated. These molecular changes suggest a persistent state of oxidative stress and may contribute to cardiac dysfunction observed in astronauts. Understanding these mechanisms is crucial for developing countermeasures to protect cardiovascular health during long-duration spaceflight, ultimately aiding future exploration missions and enhancing astronaut safety.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_007.json
+++ b/public/data/papers/exp_007.json
@@ -34,6 +34,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5666799/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5666799/pdf/ijms-18-02117.pdf"
   },
+  "ai_summary": "This study investigates the impact of space-like radiation on bone health, specifically focusing on how different types and doses of ionizing radiation affect osteoblastogenesis in mice. Researchers hypothesized that exposure to radiation would impair the formation of bone cells (osteoblasts) in a manner dependent on the type of ionizing radiation and its dose. Male C57BL6/J mice were exposed to low-linear-energy-transfer (LET) protons and high-LET iron ions at varying doses. Results indicated that high doses (200 cGy) of both radiation types significantly impaired osteoblastogenesis and altered bone microarchitecture, while lower doses had a modulating effect on redox-related gene expression. These findings highlight the potential risks of space radiation on skeletal health, particularly as it relates to aging in astronauts. Understanding these mechanisms is crucial for developing countermeasures to protect bone health during long-duration space missions, thereby enhancing astronaut safety and mission success.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_008.json
+++ b/public/data/papers/exp_008.json
@@ -32,6 +32,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5460236/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5460236/pdf/41526_2016_Article_2.pdf"
   },
+  "ai_summary": "NASA's Space Biology and Human Research Program is advancing translational research to enhance human exploration and habitation missions. The study emphasizes the importance of collaborative efforts across various scientific disciplines to address the unique challenges posed by long-duration space travel. It highlights recent examples of early-stage translational research sponsored by NASA, showcasing innovative approaches that bridge laboratory findings with real-world applications in space environments. Key findings suggest that fostering interdisciplinary partnerships can accelerate the development of solutions that ensure astronaut health and performance during missions. This research is crucial for preparing for future explorations, such as missions to Mars, where understanding biological responses to space conditions is essential. By advocating for a structured approach to translational research, NASA aims to streamline the path from scientific discovery to practical implementation, ultimately contributing to the success and safety of human spaceflight endeavors.",
   "access": [
     "PEER-REVIEWED"
   ],

--- a/public/data/papers/exp_009.json
+++ b/public/data/papers/exp_009.json
@@ -32,6 +32,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6222041/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6222041/pdf/main.pdf"
   },
+  "ai_summary": "This study addresses the challenge of assessing bone quality in small animals, specifically the response of mouse vertebrae to cyclic mechanical loading. The researchers developed a high-precision method for ex vivo cyclic compressive loading of isolated mouse vertebral bodies, utilizing 3D-printed support jigs, pivotable loading platens, and micro-CT-based finite element analysis to ensure consistent strain across specimens. Testing the new method against two established techniques, the results indicated that the new approach (K FEA method) significantly reduced variability in fatigue life, with an 8-fold lower standard deviation compared to the existing methods. This precision led to a uniform fatigue life across specimens, contrasting with the negative correlation observed in the literature methods. These findings are crucial for space biosciences, as understanding bone behavior under mechanical stress is vital for assessing the impacts of microgravity on skeletal health during long-duration space missions.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_010.json
+++ b/public/data/papers/exp_010.json
@@ -33,6 +33,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6813909/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6813909/pdf/nihms-1538854.pdf"
   },
+  "ai_summary": "This study investigates the impact of ionizing radiation on the structural integrity and mechanical properties of mouse vertebrae, focusing on the roles of collagen fragmentation and non-enzymatic crosslinking. Using ex vivo x-ray radiation on lumbar vertebrae from female C57BL/6J mice, researchers exposed samples to doses ranging from 0 to 35,000 Gy. Key findings revealed that vertebral strength, ultimate strain, and work-to-fracture significantly decreased at higher radiation doses (17,000 and 35,000 Gy), with strength reduced by 50% and 73%, respectively, compared to controls. In contrast, collagen fragmentation was more closely associated with these mechanical changes than non-enzymatic crosslinking. These results underscore the detrimental effects of high radiation exposure on bone quality, highlighting potential risks for astronauts during long-duration space missions. Understanding these mechanisms is crucial for developing strategies to mitigate bone loss and maintain skeletal health in space environments.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_011.json
+++ b/public/data/papers/exp_011.json
@@ -32,6 +32,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4095884/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4095884/pdf/2044-5040-4-13.pdf"
   },
+  "ai_summary": "This study investigates the role of γ-sarcoglycan in mechanotransduction signaling within skeletal muscle, particularly focusing on p70S6 kinase (p70S6K) responses to mechanical stretch. The research highlights that the absence of γ-sarcoglycan, a component of the dystrophin glycoprotein complex, leads to significant alterations in signaling pathways that are crucial for muscle function. Using C2C12 myotubes and muscle samples from both wild-type and γ-sarcoglycan-null mice, the authors found that stretching induced a robust activation of p70S6K in normal muscle, whereas this response was absent in γ-sarcoglycan-null samples. Notably, while p70S6K activation was calcium-independent in γ-sarcoglycan-null muscles, it remained elevated even under conditions that typically reduce its activation. These findings suggest that γ-sarcoglycan is essential for the normal mechanotransduction response, and its absence disrupts load-sensing mechanisms, potentially contributing to the pathophysiology of muscular dystrophies. This research has implications for understanding muscle degeneration and developing targeted therapies in space biosciences and beyond.",
   "access": [
     "PEER-REVIEWED",
     "MUSCULOSKELETAL ADAPTATION"

--- a/public/data/papers/exp_012.json
+++ b/public/data/papers/exp_012.json
@@ -30,6 +30,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3040128/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3040128/pdf/1471-2229-11-25.pdf"
   },
+  "ai_summary": "The study investigates the roles of AtRabD2b and AtRabD2c, two Rab GTPases, in pollen development and tube growth in Arabidopsis thaliana. While single mutants of each gene show no significant morphological differences from wild-type plants, the double mutant (AtrabD2b/2c) exhibits shorter siliques and produces deformed pollen with swollen, branched tube tips. These defects in pollen morphology lead to reduced fertility, highlighting the critical role of these proteins in pollen function. Both AtRabD2b and AtRabD2c are highly expressed in pollen and localize to Golgi bodies, suggesting their involvement in vesicle trafficking essential for pollen tube growth. The findings indicate that AtRabD2b and AtRabD2c have overlapping functions, emphasizing the importance of Rab GTPases in plant reproduction. Understanding these mechanisms is vital for advancing space biosciences, particularly in developing plants for long-duration space missions where successful reproduction is crucial for sustainability.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_013.json
+++ b/public/data/papers/exp_013.json
@@ -28,6 +28,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3177255/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3177255/pdf/514.pdf"
   },
+  "ai_summary": "This study investigates the role of TNO1, a protein interacting with the soluble N-ethylmaleimide-sensitive factor attachment protein receptor SYP41, in Arabidopsis thaliana. Researchers aimed to understand how TNO1 contributes to salt tolerance and vacuolar trafficking. Utilizing coimmunoprecipitation and immunofluorescence microscopy, TNO1 was localized to the trans-Golgi network (TGN). The tno1 mutant exhibited heightened sensitivity to various salts and osmotic stress, indicating a compromised stress response. Notably, the localization of SYP61, which plays a critical role in salt stress, was disrupted in the mutant. Additionally, the tno1 mutant showed impaired vacuolar protein trafficking, as evidenced by the secretion of vacuolar proteins to the apoplast and delayed formation of the brefeldin A compartment. These findings highlight TNO1's essential function in vesicle fusion and stress tolerance, providing insights that could inform strategies for enhancing plant resilience in extreme environments, including those encountered in space exploration.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_014.json
+++ b/public/data/papers/exp_014.json
@@ -31,6 +31,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11500582/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11500582/pdf/plantbiotechnology-41-1-23.1214a.pdf"
   },
+  "ai_summary": "This study investigates a novel protein in *Arabidopsis thaliana*, named AtGTLP (Arabidopsis thaliana Glycosyl Transferase-Like Protein), which is predicted to function as a glycosyltransferase. The research focused on the protein's subcellular localization, particularly its interaction with the trans-Golgi network-localized Qa-SNARE, SYNTAXIN OF PLANTS 43. Using fluorescence microscopy, the authors established that AtGTLP predominantly localizes to the Golgi apparatus, featuring a type II membrane topology with a single transmembrane helix and a globular C-terminal domain. Despite the absence of observable phenotypic differences in atgtlp−/− mutants, the findings suggest that AtGTLP may belong to an uncharacterized family of fucosyltransferases in plants. Understanding the role of AtGTLP enhances our knowledge of membrane trafficking and glycosylation processes, which are crucial for plant development and could have implications for biotechnological applications and space biosciences, where plant resilience and adaptation in extraterrestrial environments are of interest.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_015.json
+++ b/public/data/papers/exp_015.json
@@ -28,6 +28,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5387210/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5387210/pdf/12870_2017_Article_1024.pdf"
   },
+  "ai_summary": "This study investigates the role of TNO1, a protein localized at the trans-Golgi network, in modulating root skewing in Arabidopsis thaliana. Root movement is crucial for plant anchorage and nutrient acquisition, and this research identifies TNO1 as a significant factor influencing this process. The researchers found that knockout mutants of TNO1 exhibited enhanced root skewing and epidermal cell file rotation, particularly when microtubules were stabilized, indicating a complex interaction between TNO1 and cytoskeletal dynamics. Interestingly, the skewing was unaffected by microtubule destabilization, suggesting that TNO1's influence on root growth is independent of microtubule orientation. Additionally, TNO1 is essential for maintaining cell morphology in mature root regions. These findings highlight the importance of the trans-Golgi network and associated proteins in root development, offering insights that could inform future research in space biosciences, particularly regarding plant growth in microgravity environments where root orientation and nutrient uptake are critical.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_016.json
+++ b/public/data/papers/exp_016.json
@@ -28,6 +28,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4642138/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4642138/pdf/fpls-06-00969.pdf"
   },
+  "ai_summary": "This study investigates the role of the trans-Golgi network protein TNO1 in auxin transport and root development in Arabidopsis thaliana. Researchers found that the tno1 mutant exhibited significant defects in lateral root emergence and gravitropic responses, indicating that TNO1 is crucial for these processes. Specifically, the mutant roots showed delayed auxin transport during gravistimulation and reduced auxin asymmetry at the tips of elongating lateral roots. Despite these defects, endocytosis to the trans-Golgi network was unaffected, suggesting that TNO1's role is specific to auxin-related signaling rather than general trafficking issues. The findings highlight TNO1's importance in mediating auxin-dependent root architecture, which is vital for plant adaptation and growth. Understanding these mechanisms is essential for advancing space biosciences, particularly in developing strategies for plant growth in microgravity environments, where efficient root development and nutrient transport are critical for sustaining life.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_017.json
+++ b/public/data/papers/exp_017.json
@@ -28,6 +28,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5387210/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5387210/pdf/12870_2017_Article_1024.pdf"
   },
+  "ai_summary": "This study investigates the role of the TNO1 protein, localized at the trans-Golgi network, in regulating root skewing in *Arabidopsis thaliana*. The researchers aimed to understand how this protein influences root movement, which is crucial for plants to optimize nutrient acquisition and anchorage. They utilized knockout mutants of the TNO1 gene and observed that these mutants exhibited increased root skewing and altered epidermal cell file rotation. Notably, while the skewing intensified with microtubule stabilization, it remained unaffected by microtubule destabilization, indicating a complex relationship between TNO1 and microtubule dynamics. Furthermore, the study revealed that TNO1 is essential for maintaining cell morphology in mature root regions. These findings underscore the importance of TNO1 and the trans-Golgi network in root development, providing insights that could enhance our understanding of plant adaptability in varying environments, which is particularly relevant for space biosciences as we explore plant growth beyond Earth.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_018.json
+++ b/public/data/papers/exp_018.json
@@ -35,6 +35,7 @@
   "links": {
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2915878/"
   },
+  "ai_summary": "This study investigates the role of the Drosophila SUN protein Spag4 in maintaining the attachment between centrioles and nuclei during spermatogenesis. The researchers found that Spag4 is specifically expressed in the testes and is crucial for the association of the single spermatid centriole with the spermatid nucleus. In the absence of Spag4, a dissociation occurs post-meiosis, indicating its essential function in cellular organization. The study highlights that Spag4's action does not depend on the KASH proteins present in Drosophila but requires the coiled-coil protein Yuri Gagarin, which localizes similarly to Spag4 at the nuclear surface. These findings enhance our understanding of LINC complex dynamics and centrosome-nucleus interactions, which are vital for proper cellular function. This research has implications for space biosciences, as understanding these mechanisms can inform how cellular processes are affected in microgravity environments, potentially impacting reproductive health and development in space.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_019.json
+++ b/public/data/papers/exp_019.json
@@ -41,6 +41,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3901686/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3901686/pdf/pone.0086485.pdf"
   },
+  "ai_summary": "This study investigates how gravity and spaceflight affect immune responses in Drosophila, focusing on the Toll signaling pathway, which is crucial for fighting infections. Given that human immune function deteriorates in microgravity, understanding these mechanisms is vital for astronaut health. The researchers exposed Drosophila to hypergravity conditions and assessed their survival after infection with the pathogenic fungus Beauveria bassiana. Results showed that hypergravity significantly enhanced survival rates across various fly strains, suggesting that increased gravitational forces may bolster immune responses. Conversely, spaceflight altered gene transcription related to immune function, indicating that microgravity may impair these responses. These findings highlight the complex interplay between gravity and immune function, underscoring the need for further research to develop effective countermeasures for maintaining astronaut health during long-duration space missions. Understanding these biological responses is critical for ensuring the safety and well-being of future space explorers.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_020.json
+++ b/public/data/papers/exp_020.json
@@ -29,6 +29,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6985101/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6985101/pdf/41598_2020_Article_58490.pdf"
   },
+  "ai_summary": "This study investigates the impact of spaceflight on mouse liver metabolism, focusing on lipid dysregulation across multiple missions. Researchers employed a multi-omics approach, integrating genomics, transcriptomics, and metabolomics to analyze liver samples from mice exposed to space conditions. The scientific question centered on how microgravity and radiation affect metabolic processes, particularly lipid metabolism, which is crucial for understanding health risks in long-duration space missions. Key findings revealed consistent alterations in lipid profiles, indicating a theme of dysregulation that persisted across different missions. These changes could have implications for astronaut health, as lipid metabolism is linked to various diseases, including cardiovascular issues. The results underscore the need for further investigation into countermeasures that could mitigate these metabolic disruptions, ultimately contributing to safer and healthier space travel for future missions. This research enhances our understanding of biological responses to space environments, informing strategies to protect astronaut health during extended space exploration.",
   "access": [
     "PEER-REVIEWED"
   ],

--- a/public/data/papers/exp_021.json
+++ b/public/data/papers/exp_021.json
@@ -31,6 +31,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6387434/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6387434/pdf/ijms-20-00661.pdf"
   },
+  "ai_summary": "This study investigates the long-term effects of space radiation on cardiovascular health, a growing concern for astronauts. Utilizing data from NASA's GeneLab database, researchers employed a systems biology approach to identify key molecular pathways influenced by space radiation. They compared microarray data from cardiomyocytes of male C57BL/6 mice exposed to simulated space radiation with human endothelial cells cultured on the International Space Station (ISS). The findings revealed that the FYN gene plays a pivotal role in the cardiovascular response to radiation, suggesting that initial oxidative stress is transient and leads to FYN upregulation, which subsequently reduces reactive oxygen species (ROS) levels. This protective mechanism highlights potential strategies for mitigating cardiovascular risks in astronauts. Understanding these molecular responses is crucial for developing countermeasures to safeguard astronaut health during long-duration space missions, ultimately enhancing the safety and success of future explorations beyond Earth.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_022.json
+++ b/public/data/papers/exp_022.json
@@ -29,6 +29,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6371294/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6371294/pdf/2975810.pdf"
   },
+  "ai_summary": "This study evaluates the \"FAIRness\" of NASA's GeneLab Data Systems (GLDS) and four comparable omics data systems, focusing on their ability to share and integrate biological data effectively. Using 14 FAIRness metrics, the researchers found that the systems scored between 6 and 12, with an average score of 10.1, indicating moderate performance in data sharing. Notably, while data findability and accessibility were rated relatively high, interoperability was a significant weakness, with many systems failing to support the reusability of metadata. These findings highlight critical gaps in data integration capabilities, which are essential for advancing research in space biosciences. The study emphasizes the need for improved interoperability and proposes two new principles for developers to enhance data accessibility. By addressing these issues, the research aims to foster collaborative investigations that can better support biomedical research relevant to both space exploration and terrestrial applications.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_023.json
+++ b/public/data/papers/exp_023.json
@@ -38,6 +38,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7072278/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7072278/pdf/cancers-12-00381.pdf"
   },
+  "ai_summary": "This study investigates the biological responses of animal models to space radiation, particularly focusing on the effects of galactic cosmic rays (GCR) on astronaut health during extended missions. Utilizing the extensive NASA GeneLab database, researchers analyzed multiple omics datasets from both ground-based and spaceflight experiments, examining radiation exposure across various ion types and doses. Key findings revealed distinct biological signatures linked to specific ions, highlighting dose-dependent changes in mitochondrial function, ribosomal assembly, and immune pathways. The analysis encompassed data from diverse tissues, providing insights into the cellular mechanisms affected by radiation. This research underscores the potential risks posed by ionizing radiation in space environments and demonstrates how GeneLab's comprehensive resources can enhance our understanding of these effects, ultimately informing strategies to safeguard astronaut health during long-duration space missions. The findings are crucial for advancing space biosciences and developing effective countermeasures against radiation exposure.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_024.json
+++ b/public/data/papers/exp_024.json
@@ -61,6 +61,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8441986/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8441986/pdf/nihms-1653539.pdf"
   },
+  "ai_summary": "This study investigates a microRNA (miRNA) signature linked to spaceflight, revealing critical insights for countermeasure development in space biosciences. Researchers identified a shared miRNA response in rodents and humans exposed to simulated short- and long-duration spaceflight conditions. Utilizing data from the NASA Twins Study, they confirmed the expression of specific miRNAs through advanced sequencing techniques. Notably, miR-125, miR-16, and let-7a were found to mitigate vascular damage induced by simulated deep space radiation. The study employed antagomirs to inhibit these miRNAs, demonstrating their physiological relevance by successfully rescuing damage in human 3D vascular constructs. These findings underscore the potential of targeting miRNA pathways to develop therapeutic strategies for protecting astronauts from the adverse effects of spaceflight, enhancing human health during long-duration missions. This research paves the way for future investigations into miRNA-based countermeasures, contributing significantly to the field of space biosciences.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_025.json
+++ b/public/data/papers/exp_025.json
@@ -34,6 +34,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC9400218/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC9400218/pdf/40168_2022_Article_1332.pdf"
   },
+  "ai_summary": "This study investigates antimicrobial resistance (AMR) within the microbiome of the International Space Station (ISS), a critical concern for long-duration space missions. Utilizing shotgun metagenomics data from the Microbial Tracking–1 project, researchers analyzed samples from various ISS locations over 12 months, focusing on 226 cultivable strains and metagenome-assembled genomes (MAGs). By employing a deep learning model, the study identified a broader range of AMR genes than traditional methods, revealing a significant presence of AMR in the bacterium Kalamiella piersonii during the last flight. Notably, strains of Enterobacter bugandensis and Bacillus cereus exhibited high resistance to beta-lactam antibiotics, confirmed through experimental validation. These findings underscore the potential risks posed by AMR in space environments, emphasizing the need for ongoing monitoring and strategies to mitigate microbial threats during future space exploration. The research enhances our understanding of the ISS microbiome and its implications for human health in extraterrestrial settings.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_026.json
+++ b/public/data/papers/exp_026.json
@@ -46,6 +46,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC9267413/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC9267413/pdf/ijms-23-07465.pdf"
   },
+  "ai_summary": "This review examines the potential risks of gynecological cancers in female astronauts due to the unique challenges of spaceflight, particularly microgravity and ionizing radiation from galactic cosmic rays. Historically, women have had limited opportunities for long-duration space missions due to their higher susceptibility to radiation-induced cancers, including breast and ovarian cancers. The authors highlight a significant gap in research regarding the effects of space conditions on the female reproductive system, noting that current data is insufficient to assess the risks accurately. As upcoming Artemis missions aim to send women to the Moon for extended periods, it is crucial to understand how prolonged exposure to microgravity and radiation may influence gynecological cancer risks. The findings underscore the need for targeted studies to ensure the safety and health of female astronauts, particularly in light of their heightened vulnerability to radiation. This research is vital for developing effective screening and management strategies for women in space exploration.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_027.json
+++ b/public/data/papers/exp_027.json
@@ -34,6 +34,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC9576569/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC9576569/pdf/main.pdf"
   },
+  "ai_summary": "This study investigates the effects of spaceflight on muscle and liver tissues in mice, focusing on gene expression related to muscle atrophy and metabolic processes. Researchers analyzed the transcriptomes of liver and quadriceps from mice exposed to 37 days of microgravity during the NASA Rodent Research 1 mission. They discovered that lipid metabolism was significantly disrupted in both organs, with specific gene expression patterns in the liver linked to energy conservation mechanisms that influenced muscle gene expression related to atrophy. Notably, the study identified a correlation between impaired lipid metabolism and muscle atrophy, suggesting that these processes are interconnected during spaceflight. The findings highlight the physiological challenges posed by microgravity and suggest that dietary interventions could mitigate these effects, which is crucial for long-term human space exploration. Understanding these metabolic interactions is essential for developing strategies to preserve astronaut health in future missions.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_028.json
+++ b/public/data/papers/exp_028.json
@@ -31,6 +31,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10789781/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10789781/pdf/41598_2024_Article_51756.pdf"
   },
+  "ai_summary": "This study investigates the effects of galactic cosmic radiation (GCR) on DNA methylation patterns, focusing on how chromosomal positioning and epigenetic architecture influence cellular responses. Utilizing human bronchial epithelial cell data, researchers exposed cells to high-LET (56Fe, 28Si) and low-LET (X-ray) radiation. The results revealed that 56Fe significantly increases DNA methylation levels, while 28Si and X-ray radiation lead to transient decreases in methylation. Specifically, the study identified over 24,000 differentially methylated probes for various radiation types, highlighting the distinct epigenetic responses elicited by different radiation energies. The findings underscore the importance of nuclear chromatin architecture in mediating these responses, providing critical insights into the biological impacts of prolonged GCR exposure. This research is vital for understanding potential health risks associated with long-duration space missions, informing protective measures for astronauts and advancing the field of space biosciences.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_029.json
+++ b/public/data/papers/exp_029.json
@@ -46,6 +46,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10772081/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10772081/pdf/41431_2023_Article_1462.pdf"
   },
+  "ai_summary": "This review explores the biological impacts of SARS-CoV-2, the virus responsible for COVID-19, particularly focusing on post-acute sequelae and the resultant tissue and organ adaptations. As the virus continues to evolve, understanding its effects on human physiology is crucial for addressing the ongoing health crisis. The authors synthesize findings from virological, animal, and clinical studies to elucidate the mechanisms behind the diverse clinical manifestations observed in COVID-19 patients. Key findings reveal that SARS-CoV-2 leads to complex physiological changes that vary across different organ systems, highlighting the interplay between viral infection and host responses. The review emphasizes the need for further research to fill knowledge gaps and identifies potential biochemical targets for therapeutic intervention. By advancing our understanding of the virus's systemic effects, this work contributes to the broader field of space biosciences, where similar mechanisms may influence human health in extraterrestrial environments.",
   "access": [
     "PEER-REVIEWED",
     "ISS"

--- a/public/data/papers/exp_030.json
+++ b/public/data/papers/exp_030.json
@@ -58,6 +58,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11166946/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11166946/pdf/41598_2024_Article_57948.pdf"
   },
+  "ai_summary": "This study investigates the impact of spaceflight on biomarkers associated with aging and frailty, addressing a critical gap in our understanding of astronaut health. By analyzing gene expression data from both murine models and astronauts involved in the JAXA and Inspiration4 missions, researchers sought to identify molecular changes indicative of frailty—a syndrome linked to biological aging. The analysis revealed significant alterations in the expression of frailty-related genes across various muscle tissues in mice during spaceflight, with notable upregulation observed in the gastrocnemius, extensor digitorum longus, quadriceps, soleus, and tibialis anterior muscles. These findings suggest that spaceflight may induce a frailty-like condition, paralleling changes seen in aging on Earth. Understanding these molecular shifts is vital for developing countermeasures to protect astronaut health during long-duration missions, ultimately enhancing the safety and effectiveness of human space exploration. This research underscores the importance of monitoring biological markers in space to mitigate health risks associated with prolonged exposure to microgravity.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_031.json
+++ b/public/data/papers/exp_031.json
@@ -63,6 +63,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11166944/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11166944/pdf/41467_2024_Article_48920.pdf"
   },
+  "ai_summary": "This study investigates the potential of targeting specific microRNAs (miRNAs) to mitigate the damaging effects of space radiation on human cells, a critical concern for long-duration space missions. Researchers focused on three miRNAs—miR-16-5p, miR-125b-5p, and let-7a-5p—using RNA sequencing and transcriptomic analysis on 3D microvessel cell cultures exposed to simulated Galactic Cosmic Radiation. The application of antagomirs, which inhibit these miRNAs, resulted in significant reductions in inflammation and DNA double strand breaks, alongside the restoration of mitochondrial function. Notably, the combination of all three antagomirs proved more effective than individual treatments. The findings were further supported by data from astronauts involved in NASA's Twin Study and other missions, demonstrating that the genes and pathways affected by these miRNAs are also altered in humans. This research offers a promising countermeasure strategy to protect astronauts from radiation damage, enhancing the safety and viability of future space exploration.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_032.json
+++ b/public/data/papers/exp_032.json
@@ -47,6 +47,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11166968/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11166968/pdf/41467_2023_Article_44357.pdf"
   },
+  "ai_summary": "As non-governmental space exploration gains momentum, ethical considerations surrounding the selection of space travelers and the conduct of human subject research have become increasingly critical. This study highlights the pressing need for unified ethical guidelines to ensure the safety and well-being of a diverse array of space travelers participating in commercial and private missions. With initiatives like Inspiration4 and the Polaris missions transitioning from concept to reality, the absence of stringent governmental oversight raises concerns about ethical standards in medical research and decision-making in space. The authors emphasize the importance of establishing robust protocols that address the unique challenges posed by non-governmental operations, including the selection process for space travelers and the complexities of conducting medical research in such an environment. By advocating for comprehensive ethical frameworks, this research aims to safeguard human health and uphold the highest medical standards in the evolving landscape of space exploration, ensuring that future missions prioritize ethical integrity alongside scientific advancement.",
   "access": [
     "PEER-REVIEWED",
     "ISS"

--- a/public/data/papers/exp_033.json
+++ b/public/data/papers/exp_033.json
@@ -33,6 +33,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7000411/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7000411/pdf/41526_2019_Article_91.pdf"
   },
+  "ai_summary": "This study investigates how spaceflight and simulated microgravity conditions affect the virulence of the bacterium Serratia marcescens using the Drosophila melanogaster model. Researchers found that bacteria grown aboard the International Space Station exhibited significantly increased lethality compared to ground-based controls, with Drosophila survival rates markedly lower when infected with spaceflight-exposed strains. Notably, this heightened virulence did not persist once the bacteria were returned to Earth, indicating that the changes were likely temporary rather than genetic. Additionally, similar increases in virulence were observed in bacteria cultured under simulated microgravity conditions on Earth. The findings underscore the complex interplay between host immune responses and pathogen behavior in space environments, highlighting potential risks for astronaut health during long-duration missions. Understanding these dynamics is critical for developing effective countermeasures to protect astronauts from infections in space, thereby advancing the field of space biosciences.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_034.json
+++ b/public/data/papers/exp_034.json
@@ -43,6 +43,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7787258/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7787258/pdf/nihms-1653536.pdf"
   },
+  "ai_summary": "This study investigates the impact of microgravity on cardiac function using Drosophila as a model organism, given the conservation of heart structure between flies and humans. Researchers exposed flies to microgravity aboard the International Space Station and observed significant cardiac constriction, myofibrillar remodeling, and reduced heart output. RNA sequencing of isolated hearts revealed decreased expression of sarcomeric and extracellular matrix genes alongside increased proteasomal gene expression, indicating disrupted proteostasis. Further analysis showed elevated proteasome aggregates associated with amyloid and polyglutamine deposits. Notably, in long-QT syndrome mutants, proteasomal gene expression increased in microgravity, albeit at lower levels than in wild-type flies. These findings highlight that prolonged microgravity induces cardiac remodeling and proteostatic stress, which are critical for understanding potential health risks for astronauts during long-duration space missions. This research provides insights into the fundamental biological responses of heart muscle in microgravity, informing future space bioscience studies and human health in space exploration.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_035.json
+++ b/public/data/papers/exp_035.json
@@ -28,6 +28,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8716943/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8716943/pdf/fpls-12-777119.pdf"
   },
+  "ai_summary": "This review explores the critical role of the actin cytoskeleton in the growth of primary roots, which are essential for plant stability and nutrient acquisition. The authors highlight how efficient root elongation and bending rely on a complex interplay of environmental sensing, hormonal signaling, and growth responses, all mediated by the actin network. They discuss the influence of actin-binding proteins and plant hormones on root development, as well as the effects of actin-disrupting drugs. A key finding is the identification of longitudinally oriented actin bundles as vital for cell elongation, along with the actin cytoskeleton's involvement in protein trafficking and vacuolar reshaping. The review also emphasizes the feedback mechanisms between actin organization and root responses to light and gravity. Understanding these processes is crucial for advancing space biosciences, as it can inform strategies for optimizing plant growth in extraterrestrial environments, where resource availability and environmental conditions differ significantly from Earth.",
   "access": [
     "PEER-REVIEWED",
     "SPACE BOTANY"

--- a/public/data/papers/exp_036.json
+++ b/public/data/papers/exp_036.json
@@ -32,6 +32,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4826010/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4826010/pdf/PC_TPC201500794RAR2.pdf"
   },
+  "ai_summary": "This study investigates the role of the HYPERSENSITIVE TO LATRUNCULIN B1 (HLB1) protein in Arabidopsis thaliana, focusing on its function within the endomembrane system, crucial for plant development. HLB1, identified through a forward-genetic screen, is a tetratricopeptide repeat domain-containing protein that associates with the trans-Golgi network and early endosomes, suggesting its involvement in linking post-Golgi traffic to the actin cytoskeleton. The researchers discovered that hlb1 mutants exhibited increased sensitivity to actin-disrupting drugs, such as latrunculin B and cytochalasins, leading to impaired root growth. Genetic analysis revealed that HLB1 operates in conjunction with the MIN7/BEN1 protein, which is also involved in endocytic trafficking. These findings highlight the importance of HLB1 in maintaining cellular organization and transport processes in plants. Understanding such mechanisms is vital for advancing space biosciences, particularly in developing resilient plant systems for long-duration space missions, where effective nutrient transport and growth are essential for sustainability.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_037.json
+++ b/public/data/papers/exp_037.json
@@ -21,6 +21,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6048781/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC6048781/pdf/TPC_201800316D.pdf"
   },
+  "ai_summary": "This study investigates the role of the receptor-like kinase ERULUS in regulating root hair growth by maintaining tip-focused cytoplasmic calcium oscillations in plants. The researchers aimed to understand how ERULUS influences the spatial distribution of calcium signals, which are crucial for root hair development. Using a combination of genetic, biochemical, and imaging techniques, the team demonstrated that ERULUS localizes to the plasma membrane and is essential for proper calcium signaling in root hairs. They found that mutations in the ERULUS gene resulted in disrupted calcium oscillations, leading to impaired root hair growth. These findings highlight the importance of ERULUS in plant development and suggest that manipulating calcium signaling pathways could enhance root hair formation. This research has significant implications for space biosciences, as understanding plant growth mechanisms in microgravity could inform strategies for sustainable food production during long-duration space missions.",
   "access": [
     "PEER-REVIEWED"
   ],

--- a/public/data/papers/exp_038.json
+++ b/public/data/papers/exp_038.json
@@ -35,6 +35,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7010715/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7010715/pdf/fpls-11-00005.pdf"
   },
+  "ai_summary": "This study investigates how brassinosteroids, specifically epi-brassinolide (eBL), influence root gravitropism in maize (Zea mays) by altering filamentous-actin (F-actin) dynamics. Gravitropism is the process where roots grow downward in response to gravity, and the researchers hypothesized that eBL enhances this response similarly to the actin inhibitor latrunculin B (LatB). Using a two-dimensional clinostat to simulate microgravity, the team treated maize roots with either eBL or LatB and observed their growth patterns. Both treatments resulted in enhanced downward growth and persistent curvature under clinorotation, indicating that eBL affects root directionality by modifying F-actin organization, albeit less dramatically than LatB. These findings are significant for space biosciences, as understanding plant responses to altered gravitational conditions is crucial for future space agriculture and the sustainability of long-term human missions beyond Earth.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_039.json
+++ b/public/data/papers/exp_039.json
@@ -29,6 +29,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7503278/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7503278/pdf/ijms-21-06385.pdf"
   },
+  "ai_summary": "This study investigates the dynamics of cytoplasmic calcium ([Ca²⁺] cyt) signaling in different cell types of Arabidopsis thaliana seedling roots using genetically-encoded calcium indicators (GCaMP3). Recognizing that various root cell types may respond differently to environmental stimuli, the researchers developed lines expressing GCaMP3 in five specific cell types: columella, endodermis, cortex, epidermis, and trichoblasts. Through confocal microscopy, they observed distinct [Ca²⁺] cyt responses to treatments with ATP, glutamate, aluminum, and salt, revealing both similarities and differences in calcium signaling patterns among the cell types. Notably, the study found that the responses could be influenced by growth conditions, suggesting that methodological adjustments can enhance the reliability of calcium signaling measurements. These findings enhance our understanding of plant cellular responses to environmental changes, which is crucial for advancing space biosciences, particularly in developing resilient crops for long-duration space missions where environmental conditions can be unpredictable.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_040.json
+++ b/public/data/papers/exp_040.json
@@ -33,6 +33,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8364238/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8364238/pdf/koab115.pdf"
   },
+  "ai_summary": "This study investigates the roles of SPIRRIG (SPI) and components of the WAVE/SCAR (W/SC) complex in the development of root hairs in Arabidopsis thaliana, focusing on their spatial and temporal localization. Root hairs are crucial for nutrient and water absorption, achieving their shape through a process known as tip growth, which relies on the coordination of the actin cytoskeleton and endomembrane systems. The researchers found that SPI localizes at the apex of root hairs, promoting tip growth by facilitating vesicle secretion and maintaining actin integrity. In contrast, W/SC components BRK1 and SCAR2 mark the initiation domain for root hair emergence. Mutants lacking SPI exhibited reduced tip growth, while those deficient in BRK1 and SCAR2 showed disrupted hair positioning. These findings enhance our understanding of cellular mechanisms governing root hair development, which is vital for optimizing plant growth in various environments, including space, where resource efficiency is critical for sustaining life.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_041.json
+++ b/public/data/papers/exp_041.json
@@ -52,6 +52,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11579474/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11579474/pdf/41598_2024_Article_79315.pdf"
   },
+  "ai_summary": "This study explored the effects of varying gravitational conditions—microgravity, lunar gravity (1/6 g), and Earth gravity (1 g)—on the skeletal and immune systems of C57BL/6J mice during a 25-35 day mission aboard the International Space Station. Researchers aimed to understand how these environments impact bone density, thymus health, and immune function. Key findings revealed that while microgravity led to significant bone density loss and thymus atrophy, recovery was observed when mice were subjected to 1 g, with partial recovery under lunar gravity. Gene expression related to bone health and immune response showed alterations, indicating that lunar gravity can mitigate some adverse effects of microgravity. Notably, while histological changes were absent in the spleen, gene expression variations were detected. These results highlight the importance of gravitational conditions in space travel, providing insights that could inform future human space missions and the development of countermeasures to protect astronaut health in long-duration spaceflights.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_042.json
+++ b/public/data/papers/exp_042.json
@@ -31,6 +31,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2998437/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2998437/pdf/pbio.1000555.pdf"
   },
+  "ai_summary": "This study investigates the oligomeric state of the mechanosensitive channel MscL from Staphylococcus aureus (SaMscL), a critical protein that senses membrane tension. Previous research indicated conflicting models, suggesting SaMscL could exist as a tetramer or a pentamer. Using a novel disulfide-trapping technique, the researchers determined that SaMscL predominantly forms pentamers in vivo, establishing this configuration as the physiologically relevant state. In vitro analyses revealed that detergent solubilization could alter the oligomeric state, shifting from pentamers to tetramers. These findings underscore the importance of environmental conditions on protein structure and function, which is crucial for understanding mechanosensation in bacteria and potentially in higher organisms. This research not only clarifies the structural biology of MscL but also highlights the implications for studying membrane proteins in various contexts, including space biosciences, where understanding cellular responses to mechanical forces is vital for long-duration missions.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_043.json
+++ b/public/data/papers/exp_043.json
@@ -27,6 +27,7 @@
   "links": {
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3005423/"
   },
+  "ai_summary": "This study investigates the MscL channel, a bacterial mechanosensor that acts as a biological valve for solute release during osmotic downshock, to explore its potential as a nanovalve for targeted drug delivery. Researchers introduced charged compounds into the MscL pore lumen to assess their impact on the permeation of large charged molecules. Using in vivo assays and electrophysiological techniques, they discovered that the presence of a charge significantly influences the channel's permeability, revealing an unexpected anionic preference in wild-type MscL. The findings indicate that MscL can be engineered to function as a controllable nanoswitch, responding to external stimuli like light or pH. This research has critical implications for space biosciences, as it enhances the understanding of how to manipulate biological systems for drug delivery in microgravity environments, potentially improving therapeutic strategies for astronauts and advancing biotechnological applications.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_044.json
+++ b/public/data/papers/exp_044.json
@@ -29,6 +29,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3190158/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3190158/pdf/pro0020-1638.pdf"
   },
+  "ai_summary": "This study investigates the oligomeric state of the mechanosensitive channel of large conductance (MscL) from Staphylococcus aureus, a protein crucial for cell survival during osmotic stress. Previous research indicated conflicting oligomeric structures—pentameric and tetrameric—based on crystallization methods. To clarify this, the authors employed an in vivo disulfide-trapping technique to analyze various C-terminal truncations of MscL. The findings confirm that the full-length S. aureus MscL exists as a pentamer in native membranes, aligning with recent studies that challenge earlier interpretations of its tetrameric form. This research highlights the influence of protein manipulation on oligomeric state determinations and underscores the importance of studying proteins in their native environments. Understanding the structural dynamics of MscL is vital for advancing space biosciences, as it may inform strategies for engineering resilient microbial life for long-duration space missions, where osmotic challenges are prevalent.",
   "access": [
     "PEER-REVIEWED",
     "Space Shuttle",

--- a/public/data/papers/exp_045.json
+++ b/public/data/papers/exp_045.json
@@ -32,6 +32,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3289768/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3289768/pdf/nihms347401.pdf"
   },
+  "ai_summary": "This study investigates the modulation of the MscL mechanosensitive channel, a bacterial protein that protects cells from lysis during osmotic stress. MscL's ability to be genetically modified positions it as a potential nanovalve for applications in microelectronics and targeted drug delivery. The researchers explored three methods to adjust the channel's conductance: shortening the linker between the transmembrane and cytoplasmic domains, cross-linking, and heavy metal coordination. Their findings reveal that these modifications effectively reduce channel conductance, with some changes being reversible. Notably, the stability of the cytoplasmic bundle remains intact during channel gating, suggesting that the MscL can be engineered to create smaller pore sizes. This research not only enhances our understanding of mechanosensitive channels but also opens avenues for developing more adaptable biosensors and nanotechnology devices, which could have significant implications for space biosciences and other fields requiring precise control of molecular transport.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_046.json
+++ b/public/data/papers/exp_046.json
@@ -29,6 +29,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3508904/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3508904/pdf/chan-6-255.pdf"
   },
+  "ai_summary": "This study investigates the protein-protein interactions between the S1 region and the cytoplasmic interface of TM2 in the mechanosensitive channel MscL, which plays a crucial role in bacterial osmoregulation. Using an in vivo disulfide trapping assay on 143 double-cysteine mutants of E. coli MscL, researchers mapped interactions that occur as the channel transitions from a closed to an open state. The results revealed that the S1 and TM2 ci domains interact very efficiently, requiring minimal oxidizing agent to facilitate disulfide bond formation, indicating strong coupling between these regions during gating. This work enhances our understanding of how MscL senses mechanical stimuli and opens in response to osmotic changes, providing insights into the fundamental mechanisms of mechanotransduction in cells. Such knowledge is vital for advancing space biosciences, where understanding protein behavior under altered gravitational and osmotic conditions can inform the development of life-support systems and biotechnological applications in space exploration.",
   "access": [
     "PEER-REVIEWED",
     "Space Shuttle",

--- a/public/data/papers/exp_047.json
+++ b/public/data/papers/exp_047.json
@@ -28,6 +28,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3430326/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3430326/pdf/zjb4802.pdf"
   },
+  "ai_summary": "Single-celled organisms face extreme environmental challenges, particularly rapid decreases in external osmolarity, which can lead to dangerous internal pressure build-up. To prevent cell lysis, many microbes utilize mechanosensitive channels, specifically the MscS and MscL families, which function as emergency release valves to expel cytoplasmic solutes. This study explores the roles of these channels, revealing that while they are crucial for microbial survival, their presence in plant organelles and various fungi complicates the understanding of their physiological functions. By comparing MscS and MscL, the research highlights their structural and functional models, emphasizing their significance beyond simple osmotic regulation. These findings are vital for space biosciences, as understanding microbial resilience mechanisms can inform strategies for life support systems in extraterrestrial environments, where organisms may encounter similar osmotic stressors.",
   "access": [
     "PEER-REVIEWED",
     "SPACE BOTANY"

--- a/public/data/papers/exp_048.json
+++ b/public/data/papers/exp_048.json
@@ -29,6 +29,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3593973/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC3593973/pdf/nihms438457.pdf"
   },
+  "ai_summary": "This study investigates the mechanosensitive channel MscL, a critical protein in bacterial osmoregulation, by examining chimeras derived from E. coli and S. aureus. The research focuses on a specific residue at the periplasmic lipid-aqueous interface, notably E. coli I49 and its S. aureus equivalent F47, which significantly impacts channel kinetics and mechanosensitivity. Using electrophysiological techniques, the authors demonstrated that variations in this region alter the open dwell time and the threshold for channel activation. One mutant exhibited pronounced hysteresis, underscoring the residue's role in channel gating dynamics. The findings suggest that this lipid-interface residue functions like a spring, modulating the energy barriers for channel opening and closure. Understanding these mechanisms is crucial for advancing our knowledge of how cells sense and respond to mechanical stimuli, which has implications for developing biosensors and therapeutic strategies in space biosciences, where microbial behavior under altered gravitational conditions is of particular interest.",
   "access": [
     "PEER-REVIEWED",
     "ISS",

--- a/public/data/papers/exp_049.json
+++ b/public/data/papers/exp_049.json
@@ -16,6 +16,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5018776/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5018776/pdf/pnas.201613046.pdf"
   },
+  "ai_summary": "This study investigates the phenomenon of horizontal gene transfer (HGT) in tardigrades, microscopic organisms known for their resilience in extreme environments, including space. Researchers analyzed the draft genome of a tardigrade and identified extensive gene transfer from various sources, including bacteria and archaea. Using advanced genomic techniques, they compared the tardigrade genome to those of other organisms, revealing that approximately 17% of its genes originated from external sources, highlighting the organism's unique evolutionary adaptations. These findings suggest that HGT plays a significant role in the genetic diversity and survival mechanisms of tardigrades, particularly in extreme conditions. Understanding these processes is crucial for space biosciences, as it may inform how life can adapt to extraterrestrial environments, potentially aiding in future astrobiological research and the search for life beyond Earth. This study underscores the importance of microbial interactions in shaping the genetic landscape of extremophiles, which could have implications for the development of biotechnological applications in space exploration.",
   "access": [
     "PEER-REVIEWED"
   ],

--- a/public/data/papers/exp_050.json
+++ b/public/data/papers/exp_050.json
@@ -19,6 +19,7 @@
     "pmc_html": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4896697/",
     "pmc_pdf": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4896697/pdf/pnas.201601149.pdf"
   },
+  "ai_summary": "This study addresses the challenge of identifying foreign genes in the genome assemblies of the extremophilic tardigrade Hypsibius dujardini, which is crucial for understanding its unique biological resilience. The authors critically respond to previous analyses by Bemm et al. and Arakawa, highlighting discrepancies in gene identification methods. They utilized advanced genomic techniques to distinguish between native and foreign genetic material, focusing on the implications for evolutionary biology and astrobiology. Key findings reveal that a significant portion of the genome may originate from horizontal gene transfer, suggesting that these foreign genes contribute to the organism's survival in extreme environments. This research underscores the importance of accurate genomic analysis in space biosciences, as understanding the genetic adaptations of tardigrades could inform the search for life beyond Earth and the development of resilient biological systems for future space exploration. The study emphasizes the need for refined methodologies in genomic research to enhance our comprehension of life's adaptability in extraterrestrial contexts.",
   "access": [
     "PEER-REVIEWED"
   ],

--- a/scripts/build-nasa-data.ts
+++ b/scripts/build-nasa-data.ts
@@ -25,6 +25,7 @@ type RawPaper = {
   };
   links?: Record<string, string>;
   summary?: string;
+  ai_summary?: string;
   metrics?: {
     keyword_counts?: KeywordCounts;
   };
@@ -53,6 +54,7 @@ type PaperDetail = PaperIndex & {
     results: string;
     conclusion: string;
   };
+  ai_summary: string;
   links: {
     taskbook?: string;
     osdr?: string;
@@ -181,6 +183,7 @@ const toDetail = (paper: RawPaper): PaperDetail => {
     keywords,
     sections: ensureSections(paper.sections),
     links: mapLinks(paper.links),
+    ai_summary: paper.ai_summary ?? paper.summary ?? '',
     access: deriveAccessTags(paper),
     citations_by_year: [],
     confidence: computeConfidence(paper),

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -4,6 +4,7 @@ import type { CitationPoint, PaperDetail, PaperIndex } from './types';
 export type PaperRecord = PaperIndex & {
   sections?: PaperDetail['sections'];
   links?: PaperDetail['links'];
+  ai_summary?: string;
   cachedAt?: number;
 };
 

--- a/src/lib/fallback.ts
+++ b/src/lib/fallback.ts
@@ -12,6 +12,8 @@ export const createFallbackPaper = (id: string): PaperDetail => ({
   access: ['ARCHIVE-STUB', 'PROVISIONAL'],
   citations_by_year: [],
   entities: ['ARCHIVE PLACEHOLDER'],
+  ai_summary:
+    'Analyst uplink unavailable. This synthetic summary placeholder confirms UI integrity until the classified channel resumes transmission.',
   sections: {
     abstract:
       'The uplink to the classified dossier degraded mid-transfer. A synthetic summary shell is on display until the secure channel stabilises.',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,7 @@ export type PaperDetail = PaperIndex & {
     results: string;
     conclusion: string;
   };
+  ai_summary: string;
   links: {
     taskbook?: string;
     osdr?: string;

--- a/src/routes/Paper.tsx
+++ b/src/routes/Paper.tsx
@@ -128,7 +128,21 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
   }, [connector]);
 
   const { paper } = data;
-  const { title, sections, authors, year, organism, platform, keywords, links, access, citations_by_year, confidence, entities } = paper;
+  const {
+    title,
+    sections,
+    authors,
+    year,
+    organism,
+    platform,
+    keywords,
+    links,
+    access,
+    citations_by_year,
+    confidence,
+    entities,
+    ai_summary,
+  } = paper;
 
   return (
     <div className="space-y-8 transmission-field">
@@ -271,8 +285,16 @@ const PaperLayout = ({ dossierId, data, activeSection, onSectionChange, onCopyLi
           <FuiCallout from="b-res" to="panel-results" variant="dotted" tone="cyan" />
           <FuiCallout from="b-con" to="panel-conclusion" variant="dotted" tone="cyan" />
 
-          <Panel title="Analyst Summary" sublabel="AI Channel" actions={<span className="text-[#5f6c75]">Uplink offline</span>}>
-            LLM summary feed is offline. This panel will populate once the analyst channel is connected.
+          <Panel
+            title="Analyst Summary"
+            sublabel="AI Channel"
+            actions={
+              <span className="text-[#5f6c75]">
+                {ai_summary && ai_summary.trim().length > 0 ? 'Uplink stable' : 'Awaiting uplink'}
+              </span>
+            }
+          >
+            <SectionContent text={ai_summary} />
           </Panel>
         </div>
 


### PR DESCRIPTION
## Summary
- persist AI-generated summaries when building dossier payloads
- display the analyst summary channel on dossier pages using the stored text
- regenerate public dossier JSON so each record contains its AI summary

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2e2025b4883299e4b567154f36bfc