### PR TITLE
Limit hero reticle overlay height

### DIFF
--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -174,7 +174,7 @@ const Home = () => {
                 showCompass
                 color="mono"
                 crosshair="diamond"
-                className="pointer-events-none absolute inset-0"
+                className="pointer-events-none absolute inset-x-0 top-0 h-[220px]"
               >
                 <span className="text-xs tracking-[0.3em] text-[rgba(217,226,223,0.78)]">CALIBRATED</span>
               </ReticleOverlay>


### PR DESCRIPTION
## Summary
- confine the mission control hero reticle overlay to the header area so the crosshair no longer spans the entire panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2ef0b99c08329bf5a9ba7ae3604d2